### PR TITLE
Improve README and configure.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,33 @@ install:
   - sudo apt-get update
   - sudo apt-get install -y valgrind
 
-compiler:
-  - gcc
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - gcc-5
+            - g++-5
+            - cmake
+            - cmake-data
+      env: COMPILER=gcc
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+            - george-edison55-precise-backports
+          packages:
+            - clang-3.7
+            - clang++-3.7
+            - cmake
+            - cmake-data
+      env: COMPILER=clang
 
 script:
   - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: cpp
 dist: trusty
 
 before_install:
-  - git submodule init
-  - git submodule update
   - ./configure.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,9 @@ install:
   - sudo apt-get update
   - sudo apt-get install -y valgrind
 
-matrix:
-  include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
-          packages:
-            - gcc-5
-            - g++-5
-            - cmake
-            - cmake-data
-      env: COMPILER=gcc
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-            - george-edison55-precise-backports
-          packages:
-            - clang-3.7
-            - clang++-3.7
-            - cmake
-            - cmake-data
-      env: COMPILER=clang
+compiler:
+  - clang
+  - gcc
 
 script:
   - ./test.sh

--- a/README.md
+++ b/README.md
@@ -15,31 +15,31 @@ Pull requests are welcome.
 - CRoaring (bitmap compression library used by this redis module)
 - cmake (build tools needed for compiling the source code)
 - redis (server needed for integration tests)
-- hiredis (redis' C client library needed for performance tests)
+- hiredis (redis client library needed for performance tests)
 
 ## Getting started
 
-Clone this repository on a directory on your machine:
+Clone this repository:
 
 ```bash
 $ git clone https://github.com/aviggiano/redis-roaring.git
 $ cd redis-roaring/
 ```
 
-Run the `configure.sh`, or manually do the following steps:
+Run the `configure.sh` script, or manually do the following steps:
 
 ```bash
 $ git submodule init
 $ git submodule update
 $ git submodule status
-# cd to deps/CRoaring and compile it and follow the build instructions on their repository
+# cd to deps/CRoaring and compile it, following the build instructions on their repository
 # cd to deps/redis and compile it
 # cd to deps/hiredis and compile it
 ```
 
 ## Build
 
-Build the the project with cmake and it will generate the Redis Module shared library, together with unit tests and performance tests.
+Build the the project with cmake and it will generate the Redis Module shared library `libredis-roaring.so`, together with unit tests and performance tests.
 
 ```bash
 mkdir -p build

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ git submodule status
 
 ## Build
 
-Build the the project with cmake and it will generate the Redis Module shared library `libredis-roaring.so`, together with unit tests and performance tests.
+Build the project with cmake and it will generate the Redis Module shared library `libredis-roaring.so`, together with unit tests and performance tests.
 
 ```bash
 mkdir -p build

--- a/README.md
+++ b/README.md
@@ -5,21 +5,41 @@ Roaring Bitmaps for Redis
 ## Intro
 
 This project uses the [CRoaring](https://github.com/RoaringBitmap/CRoaring) library to implement roaring bitmap commands for Redis.
+These commands have the same performance as redis' native bitmaps for *O(1)* operations and are [up to 8x faster](#performance) for *O(N)*
+calls, while consuming less memory than their uncompressed counterparts (benchmark pending).
 
 Pull requests are welcome.
 
 ## Dependencies
 
-- CRoaring (redis module)
-- cmake (build)
-- redis (integration tests)
-- hiredis (performance tests)
+- CRoaring (bitmap compression library used by this redis module)
+- cmake (build tools needed for compiling the source code)
+- redis (server needed for integration tests)
+- hiredis (redis' C client library needed for performance tests)
+
+## Getting started
+
+Clone this repository on a directory on your machine:
+
+```bash
+$ git clone https://github.com/aviggiano/redis-roaring.git
+$ cd redis-roaring/
+```
+
+Run the `configure.sh`, or manually do the following steps:
+
+```bash
+$ git submodule init
+$ git submodule update
+$ git submodule status
+# cd to deps/CRoaring and compile it and follow the build instructions on their repository
+# cd to deps/redis and compile it
+# cd to deps/hiredis and compile it
+```
 
 ## Build
 
-Run the `configure.sh` script and it will compile the source code as a static library which will be linked to **redis-roaring**. Alternatively initialize and update the CRoaring git submodule and follow the build instructions on their repository.
-
-Then build the project with cmake and it will generate the Redis Module shared library.
+Build the the project with cmake and it will generate the Redis Module shared library, together with unit tests and performance tests.
 
 ```bash
 mkdir -p build
@@ -30,7 +50,8 @@ make
 
 ## Tests
 
-Run the `test.sh` script for unit tests and integration tests.
+Run the `test.sh` script for unit tests, integration tests and performance tests.
+The performance tests can take a while, since they run on a real dataset of integer values.
 
 ## API
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+function configure_submodules()
+{
+  git submodule init
+  git submodule update
+  git submodule status
+}
 function configure_croaring()
 {
   pushd .
-
-  git submodule init
-  git submodule update
 
   cd deps/CRoaring
 
@@ -33,6 +36,7 @@ function configure_hiredis()
   cd -
 }
 
+configure_submodules
 configure_croaring
 configure_redis
 configure_hiredis


### PR DESCRIPTION
- Rewrite `README.md` and `configure.sh` to be more explicit about what the configuration scripts do.
- Add `clang` to travis

Fix #37