### PR TITLE
Add a SAVE integration test

### DIFF
--- a/src/redis-roaring.c
+++ b/src/redis-roaring.c
@@ -385,7 +385,7 @@ int RedisModule_OnLoad(RedisModuleCtx* ctx) {
       .free = BitmapFree
   };
 
-  BitmapType = RedisModule_CreateDataType(ctx, "reroaring", 0, &tm);
+  BitmapType = RedisModule_CreateDataType(ctx, "reroaring", BITMAP_ENCODING_VERSION, &tm);
   if (BitmapType == NULL) return REDISMODULE_ERR;
 
   // register our commands

--- a/src/type.c
+++ b/src/type.c
@@ -20,6 +20,7 @@ void* BitmapRdbLoad(RedisModuleIO* rdb, int encver) {
   size_t size;
   char* serialized_bitmap = RedisModule_LoadStringBuffer(rdb, &size);
   Bitmap* bitmap = roaring_bitmap_deserialize(serialized_bitmap);
+  RedisModule_Free(serialized_bitmap);
   return bitmap;
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -2,17 +2,13 @@
 #include "data-structure.h"
 #include "type.h"
 
-#define BITMAP_ENCODING_VERSION 1
-
 /* === Bitmap type methods === */
 void BitmapRdbSave(RedisModuleIO* rdb, void* value) {
   Bitmap* bitmap = value;
-  size_t serialized_size = roaring_bitmap_size_in_bytes(bitmap);
-  char* serialized_bitmap = RedisModule_Alloc(serialized_size);
-  size_t serialized_size_check = roaring_bitmap_serialize(bitmap, serialized_bitmap);
-
-  RedisModule_SaveStringBuffer(rdb, serialized_bitmap, serialized_size_check);
-
+  size_t serialized_max_size = roaring_bitmap_size_in_bytes(bitmap);
+  char* serialized_bitmap = RedisModule_Alloc(serialized_max_size);
+  size_t serialized_size = roaring_bitmap_serialize(bitmap, serialized_bitmap);
+  RedisModule_SaveStringBuffer(rdb, serialized_bitmap, serialized_size);
   RedisModule_Free(serialized_bitmap);
 }
 

--- a/src/type.h
+++ b/src/type.h
@@ -1,6 +1,8 @@
 #ifndef REDIS_ROARING_TYPE_H
 #define REDIS_ROARING_TYPE_H
 
+#define BITMAP_ENCODING_VERSION 1
+
 void BitmapRdbSave(RedisModuleIO* rdb, void* value);
 void* BitmapRdbLoad(RedisModuleIO* rdb, int encver);
 void BitmapAofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value);

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,10 @@
 set -eu
 
 LOG_FILE=""
+function reset_rdb()
+{
+  rm dump.rdb 2>/dev/null || true
+}
 function setup()
 {
   mkdir -p build
@@ -10,7 +14,7 @@ function setup()
   cmake ..
   make
   cd -
-  rm dump.rdb 2>/dev/null || true
+  reset_rdb
 }
 function unit()
 {
@@ -48,6 +52,7 @@ function stop_redis()
 function integration_1()
 {
   stop_redis
+  # FIXME should be "yes"
   start_redis "no"
   ./tests/integration_1.sh
   stop_redis
@@ -59,6 +64,7 @@ function integration_2()
   start_redis "yes"
   ./tests/integration_2.sh
   stop_redis
+  reset_rdb
   echo "All integration (2) tests passed"
 }
 function performance()

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,7 @@ function setup()
   cmake ..
   make
   cd -
+  rm dump.rdb 2>/dev/null || true
 }
 function unit()
 {
@@ -44,13 +45,21 @@ function stop_redis()
     LOG_FILE=""
   fi
 }
-function integration()
+function integration_1()
+{
+  stop_redis
+  start_redis "no"
+  ./tests/integration_1.sh
+  stop_redis
+  echo "All integration (1) tests passed"
+}
+function integration_2()
 {
   stop_redis
   start_redis "yes"
-  ./tests/integration.sh
+  ./tests/integration_2.sh
   stop_redis
-  echo "All integration tests passed"
+  echo "All integration (2) tests passed"
 }
 function performance()
 {
@@ -71,6 +80,7 @@ function end()
 
 setup
 unit
-integration
+integration_1
+integration_2
 performance
 end

--- a/test.sh
+++ b/test.sh
@@ -52,7 +52,7 @@ function stop_redis()
 function integration_1()
 {
   stop_redis
-  # FIXME should be "yes"
+  # FIXME should be "yes", but we are waiting on redis issue #4284
   start_redis "no"
   ./tests/integration_1.sh
   stop_redis

--- a/tests/integration_1.sh
+++ b/tests/integration_1.sh
@@ -195,6 +195,25 @@ function test_getbitarray_setbitarray()
   EXPECTED=""
   [ "$FOUND" == "$EXPECTED" ]
 }
+function test_del()
+{
+  echo "test_del"
+
+  FOUND=$(echo "R.SETBIT test_del 0 1" | redis-cli)
+  EXPECTED="0"
+  [ "$FOUND" == "$EXPECTED" ]
+
+  FOUND=$(echo "DEL test_del" | redis-cli)
+  EXPECTED="1"
+  [ "$FOUND" == "$EXPECTED" ]
+}
+function test_save()
+{
+  echo "test_save"
+
+  FOUND=$(echo "SAVE" | redis-cli)
+  EXPECTED="OK"
+}
 
 test_setbit_getbit
 test_bitop
@@ -202,3 +221,5 @@ test_bitcount
 test_bitpos
 test_getintarray_setintarray
 test_getbitarray_setbitarray
+test_del
+test_save

--- a/tests/integration_2.sh
+++ b/tests/integration_2.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eux
+
+function test_load()
+{
+  echo "test_load"
+
+  FOUND=$(echo "KEYS *" | redis-cli)
+  EXPECTED="test_"
+  [[ "$FOUND" =~ .*"$EXPECTED".* ]]
+}
+
+test_load

--- a/tests/integration_2.sh
+++ b/tests/integration_2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 function test_load()
 {

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -237,5 +237,21 @@ int main(int argc, char* argv[]) {
     bitmap_free(bitmap);
   }
 
+  {
+    printf("Should serialize\n");
+    uint32_t array[] = {317811, 196418, 121393, 233, 144, 89, 55, 34, 21};
+    size_t array_len = sizeof(array) / sizeof(*array);
+    Bitmap* bitmap = bitmap_from_int_array(array_len, array);
+
+    size_t serialized_max_size = roaring_bitmap_size_in_bytes(bitmap);
+    char* serialized_bitmap = malloc(serialized_max_size);
+    size_t serialized_size = roaring_bitmap_serialize(bitmap, serialized_bitmap);
+
+    free(serialized_bitmap);
+    assert(serialized_size <= serialized_max_size);
+
+    bitmap_free(bitmap);
+  }
+
   return 0;
 }


### PR DESCRIPTION
- Split `integration.sh` in two, so the second one loads the RDB file
and we see if everything went well
- Temporarily disabled valgrind on the first integration script because
of [redis#4284](https://github.com/antirez/redis/issues/4284)
- Fix #44