### PR TITLE
Bugfix container startup and publish to dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN set -ex; \
     cd build; \
     cmake ..; \
     make -j; \
-    cp libredis-roaring.so /usr/local/lib/; \
+    cd ..; \
+    cp deps/CRoaring/build/libroaring.so /usr/local/lib/; \
+    cp build/libredis-roaring.so /usr/local/lib/; \
     \
     apt-get purge -y --auto-remove $BUILD_DEPS
 ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ then you can open another terminal and use `./redis-cli` to connect to the redis
 
 ## Docker
 
-It is also possible to run this project as a docker container:
+It is also possible to run this project as a docker container.
 
 ```bash
-docker build -t redis-roaring
-docker run -p 6379:6379 redis-roaring:latest
+docker run -p 6379:6379 aviggiano/redis-roaring:latest
 ```
 
 ## Tests
@@ -73,22 +72,20 @@ Missing commands:
 ## API Example
 ```
 $ redis-cli
-# add numbers from 1 util 100 to test roaring bitmap
+# create a roaring bitmap with numbers from 1 to 99
 127.0.0.1:6379> R.SETRANGE test 1 100
-# if the key `test` exists and is a roaring bitmap type, append these numbers
-# if the key `test` does not exist, add to a new roaring bitmap
 
-# get all the int numbers
+# get all the numbers as an integer array
 127.0.0.1:6379> R.GETINTARRAY test
 
-# fill up the roaring bitmap, then don't use `R.GETINTARRAY` 
+# fill up the roaring bitmap 
 # because you need 2^32*4 bytes memory and a very long time
-127.0.0.1:6379> R.SETFULL test
+127.0.0.1:6379> R.SETFULL full
 
-# but you can use `R.RANGEINTARRAY` to get numbers from 100 to 1000 
-127.0.0.1:6379> R.RANGEINTARRAY test 100 1000
+# use `R.RANGEINTARRAY` to get numbers from 100 to 1000 
+127.0.0.1:6379> R.RANGEINTARRAY full 100 1000
 
-# you can append numbers to an existing roaring bitmap
+# append numbers to an existing roaring bitmap
 127.0.0.1:6379> R.APPENDINTARRAY test 111 222 3333 456 999999999 9999990
 ```
 

--- a/configure.sh
+++ b/configure.sh
@@ -16,7 +16,6 @@ function configure_croaring()
   ./amalgamation.sh
 
   # https://github.com/RoaringBitmap/CRoaring#building-with-cmake-linux-and-macos-visual-studio-users-should-see-below
-#  rm -rf  build
   mkdir -p build
   cd build
   cmake -DBUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Debug ..


### PR DESCRIPTION
Include libroaring.so to the library folder so that REDIS can load the
dependency's binary. Improve documentation and publish this image to
dockerhub.

Fixes #41 