### PR TITLE
fixed make error for macosx

### DIFF
--- a/src/redis-roaring.c
+++ b/src/redis-roaring.c
@@ -596,7 +596,7 @@ int RBitFlip(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
   }
 
   bool should_free = false;
-  Bitmap* bitmap;
+  Bitmap* bitmap = NULL;
   if (srctype == REDISMODULE_KEYTYPE_EMPTY) {
     // "non-existent keys [...] are considered as a stream of zero bytes up to the length of the longest string"
     bitmap = bitmap_alloc();


### PR DESCRIPTION
I had reported macosx issue [here](https://github.com/aviggiano/redis-roaring/issues/80).

It seem that the redis roaring module doesn't work well under MacOSX. This pull request only fixed make issue and make the server run. After this fix, it can run, but the performance test still have an issue with libhiredis, and the performance test output is wrong. I have not look into it at the monment. 

Thanks!
