### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-redis-roaring ![CI/CD](https://github.com/aviggiano/redis-roaring/workflows/CI/CD/badge.svg)
+redis-roaring ![CI/CD](https://github.com/aviggiano/redis-roaring/actions/workflows/ci.yml/badge.svg)
 ===========
 Roaring Bitmaps for Redis
 


### PR DESCRIPTION
## Summary
- fix GitHub Actions badge path in `README.md`

## Testing
- `./test.sh` *(fails: missing submodules)*

------
https://chatgpt.com/codex/tasks/task_e_685d762d7a8483328ecc4b8be31c078b