### PR TITLE
R.STAT-resp3

### DIFF
--- a/src/redis-roaring.c
+++ b/src/redis-roaring.c
@@ -260,7 +260,7 @@ int RStatBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
   s = sdscatprintf(s, "\trun container values: %d\n", stat.n_values_run_containers);
   s = sdscatprintf(s, "\trun container bytes: %d\n", stat.n_bytes_run_containers);
 
-  RedisModule_ReplyWithStringBuffer(ctx, s, sdslen(s));
+  RedisModule_ReplyWithVerbatimString(ctx, s, sdslen(s));
   sdsfree(s);
 
   return REDISMODULE_OK;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -149,6 +149,7 @@ int REDISMODULE_API_FUNC(RedisModule_ReplyWithArray)(RedisModuleCtx *ctx, long l
 void REDISMODULE_API_FUNC(RedisModule_ReplySetArrayLength)(RedisModuleCtx *ctx, long len);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithStringBuffer)(RedisModuleCtx *ctx, const char *buf, size_t len);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithString)(RedisModuleCtx *ctx, RedisModuleString *str);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithVerbatimString)(RedisModuleCtx *ctx, const char *buf, size_t len);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithNull)(RedisModuleCtx *ctx);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply);
@@ -235,6 +236,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ReplySetArrayLength);
     REDISMODULE_GET_API(ReplyWithStringBuffer);
     REDISMODULE_GET_API(ReplyWithString);
+    REDISMODULE_GET_API(ReplyWithVerbatimString);
     REDISMODULE_GET_API(ReplyWithNull);
     REDISMODULE_GET_API(ReplyWithCallReply);
     REDISMODULE_GET_API(ReplyWithDouble);


### PR DESCRIPTION
There is a legacy issue from #111. When calling the R.STAT command using redis-cli resp3, the output cannot be formatted. Therefore, the ReplyWithVerbatimString mechanism was introduced.
![Kim 2025-06-27 133842](https://github.com/user-attachments/assets/f52b9312-3219-4cfb-b3aa-4c6e164a20af)