### PR TITLE
remove_sds_dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "deps/hiredis"]
 	path = deps/hiredis
 	url = https://github.com/redis/hiredis.git
-[submodule "deps/sds"]
-	path = deps/sds
-	url = https://github.com/antirez/sds.git


### PR DESCRIPTION
I found that didn’t need to depend on https://github.com/antirez/sds.git, so removed it.