### PR TITLE
Inform mem usage to Redis even if not using RM_Alloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,55 @@
 cmake_minimum_required(VERSION 3.5)
 project(redis-roaring)
-set (CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(DEPS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps)
 set(TEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+
+# CRoaring configuration
 set(ENABLE_ROARING_TESTS OFF)
 set(CROARING_PATH ${DEPS_PATH}/CRoaring)
-add_subdirectory(${CROARING_PATH} EXCLUDE_FROM_ALL)
+
+# Command line options with default values
+option(USE_REDIS_ALLOCATOR "Use redis allocator" ON)
 option(DISABLE_TESTS "disables tests in hiredis" ON)
 option(BUILD_SHARED_LIBS "use shared libraries" OFF)
 set(HIREDIS_PATH ${DEPS_PATH}/hiredis)
+
+# Include directories
+include_directories(
+  ${SRC_PATH}
+  ${DEPS_PATH}
+)
+
+add_subdirectory(${CROARING_PATH} EXCLUDE_FROM_ALL)
 add_subdirectory(${HIREDIS_PATH} EXCLUDE_FROM_ALL)
-include_directories(${SRC_PATH})
+
+# Enable testing
 enable_testing()
 
-
+# Unit tests executable
 add_executable(unit ${SRC_PATH}/data-structure.c ${TEST_PATH}/unit.c)
 target_link_libraries(unit roaring::roaring)
 add_test(NAME unit_tests COMMAND unit)
 
+# Performance tests executable
 add_executable(performance ${TEST_PATH}/performance.c)
-set (CROARING_BENCHMARK_DATA_DIR "${CROARING_PATH}/benchmarks/realdata/")
+set(CROARING_BENCHMARK_DATA_DIR "${CROARING_PATH}/benchmarks/realdata/")
 target_compile_definitions(performance PRIVATE CROARING_BENCHMARK_DATA_DIR="${CROARING_BENCHMARK_DATA_DIR}")
-target_link_libraries(performance  m roaring::roaring hiredis::hiredis)
+target_link_libraries(performance m roaring::roaring hiredis::hiredis)
 add_test(NAME performance_tests COMMAND performance)
 
+# Build the shared library
+set(REDIS_ROARING_SOURCE_FILES
+  ${SRC_PATH}/redis-roaring.c
+  ${SRC_PATH}/data-structure.c
+)
 
-set(REDIS_ROARING_SOURCE_FILES ${SRC_PATH}/redis-roaring.c
-        ${SRC_PATH}/data-structure.c)
 add_library(redis-roaring SHARED ${REDIS_ROARING_SOURCE_FILES})
-
 target_link_libraries(redis-roaring roaring::roaring hiredis::hiredis)
+
+if(USE_REDIS_ALLOCATOR)
+  target_compile_definitions(redis-roaring PRIVATE REDIS_MODULE_TARGET)
+endif()

--- a/src/data-structure.c
+++ b/src/data-structure.c
@@ -1,6 +1,7 @@
 #include "data-structure.h"
 
 #include "roaring.h"
+#include "rmalloc.h"
 
 /* === Internal data structure === */
 
@@ -222,26 +223,26 @@ Bitmap64* bitmap64_from_int_array(size_t n, const uint64_t* array) {
 
 uint32_t* bitmap_get_int_array(const Bitmap* bitmap, size_t* n) {
   *n = roaring_bitmap_get_cardinality(bitmap);
-  uint32_t* ans = malloc(sizeof(*ans) * (*n));
+  uint32_t* ans = rm_malloc(sizeof(*ans) * (*n));
   roaring_bitmap_to_uint32_array(bitmap, ans);
   return ans;
 }
 
 uint64_t* bitmap64_get_int_array(const Bitmap64* bitmap, uint64_t* n) {
   *n = roaring64_bitmap_get_cardinality(bitmap);
-  uint64_t* ans = malloc(sizeof(*ans) * (*n));
+  uint64_t* ans = rm_malloc(sizeof(*ans) * (*n));
   roaring64_bitmap_to_uint64_array(bitmap, ans);
   return ans;
 }
 
 uint32_t* bitmap_range_int_array(const Bitmap* bitmap, size_t offset, size_t n) {
-  uint32_t* ans = calloc(n, sizeof(*ans));
+  uint32_t* ans = rm_calloc(n, sizeof(*ans));
   roaring_bitmap_range_uint32_array(bitmap, offset, n, ans);
   return ans;
 }
 
 uint64_t* bitmap64_range_int_array(const Bitmap64* bitmap, uint64_t offset, uint64_t n) {
-  uint64_t* ans = calloc(n, sizeof(*ans));
+  uint64_t* ans = rm_calloc(n, sizeof(*ans));
 
   // [TODO] replace with roaring64_bitmap_range_uint64_array in next version of CRoaring
   for (uint64_t i = 0; i < n; i++) {
@@ -251,14 +252,6 @@ uint64_t* bitmap64_range_int_array(const Bitmap64* bitmap, uint64_t offset, uint
   }
 
   return ans;
-}
-
-void bitmap_free_int_array(uint32_t* array) {
-  free(array);
-}
-
-void bitmap64_free_int_array(uint64_t* array) {
-  free(array);
 }
 
 Bitmap* bitmap_from_bit_array(size_t size, const char* array) {
@@ -283,7 +276,7 @@ Bitmap64* bitmap64_from_bit_array(size_t size, const char* array) {
 
 char* bitmap_get_bit_array(const Bitmap* bitmap, size_t* size) {
   *size = roaring_bitmap_maximum(bitmap) + 1;
-  char* ans = malloc(*size + 1);
+  char* ans = rm_malloc(*size + 1);
   memset(ans, '0', *size);
   ans[*size] = '\0';
 
@@ -299,7 +292,7 @@ char* bitmap_get_bit_array(const Bitmap* bitmap, size_t* size) {
 
 char* bitmap64_get_bit_array(const Bitmap64* bitmap, uint64_t* size) {
   *size = roaring64_bitmap_maximum(bitmap) + 1;
-  char* ans = malloc(*size + 1);
+  char* ans = rm_malloc(*size + 1);
   memset(ans, '0', *size);
   ans[*size] = '\0';
 
@@ -314,7 +307,7 @@ char* bitmap64_get_bit_array(const Bitmap64* bitmap, uint64_t* size) {
 }
 
 void bitmap_free_bit_array(char* array) {
-  free(array);
+  rm_free(array);
 }
 
 Bitmap* bitmap_from_range(uint64_t from, uint64_t to) {

--- a/src/data-structure.h
+++ b/src/data-structure.h
@@ -76,8 +76,6 @@ uint32_t* bitmap_get_int_array(const Bitmap* bitmap, size_t* n);
 uint64_t* bitmap64_get_int_array(const Bitmap64* bitmap, uint64_t* n);
 uint32_t* bitmap_range_int_array(const Bitmap* bitmap, size_t offset, size_t n);
 uint64_t* bitmap64_range_int_array(const Bitmap64* bitmap, uint64_t offset, uint64_t n);
-void bitmap_free_int_array(uint32_t* array);
-void bitmap64_free_int_array(uint64_t* array);
 /**
  * Creates a Bitmap from a buffer composed from ASCII '0's and '1's
  *

--- a/src/rmalloc.h
+++ b/src/rmalloc.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#ifndef __REDISEARCH_ALLOC__
+#define __REDISEARCH_ALLOC__
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include "redismodule.h"
+
+#ifdef REDIS_MODULE_TARGET /* Set this when compiling your code as a module */
+
+static inline void *rm_malloc(size_t n) {
+  return RedisModule_Alloc(n);
+}
+static inline void *rm_calloc(size_t nelem, size_t elemsz) {
+  return RedisModule_Calloc(nelem, elemsz);
+}
+static inline void *rm_realloc(void *p, size_t n) {
+  if (n == 0) {
+    RedisModule_Free(p);
+    return NULL;
+  }
+  return RedisModule_Realloc(p, n);
+}
+static inline void rm_free(void *p) {
+  RedisModule_Free(p);
+}
+static inline char *rm_strdup(const char *s) {
+  return RedisModule_Strdup(s);
+}
+
+static char *rm_strndup(const char *s, size_t n) {
+  char *ret = (char *)rm_malloc(n + 1);
+
+  if (ret) {
+    ret[n] = '\0';
+    memcpy(ret, s, n);
+  }
+  return ret;
+}
+
+static int rm_vasprintf(char **__restrict __ptr, const char *__restrict __fmt, va_list __arg) {
+  va_list args_copy;
+  va_copy(args_copy, __arg);
+
+  size_t needed = vsnprintf(NULL, 0, __fmt, __arg) + 1;
+  *__ptr = (char *)rm_malloc(needed);
+
+  int res = vsprintf(*__ptr, __fmt, args_copy);
+
+  va_end(args_copy);
+
+  return res;
+}
+
+static int rm_asprintf(char **__ptr, const char *__restrict __fmt, ...) {
+  va_list ap;
+  va_start(ap, __fmt);
+
+  int res = rm_vasprintf(__ptr, __fmt, ap);
+
+  va_end(ap);
+
+  return res;
+}
+#endif
+#ifndef REDIS_MODULE_TARGET
+/* for non redis module targets */
+#define rm_malloc malloc
+#define rm_free free
+#define rm_calloc calloc
+#define rm_realloc realloc
+#define rm_strdup strdup
+#define rm_strndup strndup
+#define rm_asprintf asprintf
+#define rm_vasprintf vasprintf
+#endif
+
+#define rm_new(x) rm_malloc(sizeof(x))
+
+#endif /* __RMUTIL_ALLOC__ */

--- a/test_macos.sh
+++ b/test_macos.sh
@@ -6,12 +6,15 @@ set -eu
 
 function unit()
 {
-  # valgrind --leak-check=full --error-exitcode=1 ./build/unit
+  ./build/unit
   echo "All unit tests passed"
 }
+
 function integration_1()
 {
   stop_redis
+  rm dump.rdb 2>/dev/null || true
+  rm -rf ./appendonlydir
   start_redis_macos
   ./tests/integration_1.sh
   stop_redis
@@ -34,7 +37,7 @@ function integration_2()
   start_redis_macos --aof
   ./tests/integration_2.sh
   stop_redis
-  rm appendonly.aof 2>/dev/null || true
+  rm -rf ./appendonlydir
 
   echo "All integration tests passed"
 }

--- a/tests/unit/test_bitmap64_from_int_array.c
+++ b/tests/unit/test_bitmap64_from_int_array.c
@@ -19,7 +19,7 @@ void test_bitmap64_from_int_array() {
 
       ASSERT_ARRAY_EQ(array, found, array_len, n);
 
-      bitmap64_free_int_array(found);
+      SAFE_FREE(found);
       bitmap64_free(bitmap);
     }
 

--- a/tests/unit/test_bitmap_from_int_array.c
+++ b/tests/unit/test_bitmap_from_int_array.c
@@ -19,7 +19,7 @@ void test_bitmap_from_int_array() {
 
       ASSERT_ARRAY_EQ(array, found, array_len, n);
 
-      bitmap_free_int_array(found);
+      SAFE_FREE(found);
       bitmap_free(bitmap);
     }
 


### PR DESCRIPTION

This pull request introduces `rmalloc.h`, a that provides utility wrapper functions (e.g., `rm_malloc`) around `RedisModule_Alloc` functions.

- For unit or performance testing, the wrappers fall back to the standard `malloc`.
#2 
- Configures CRoaring’s memory hooks so Redis can properly account for memory usage within this library.
- Refactors `CMakeLists.txt` to improve structure.

I tried to log `malloc` calls and after this change, the number of logs during bitmap_alloc execution has significantly increased :)

