### PR TITLE
Fix heap-use-after-free in bitmap OR append operation

### DIFF
--- a/tests/fuzz/fuzz_bitmap64_api.c
+++ b/tests/fuzz/fuzz_bitmap64_api.c
@@ -120,8 +120,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 if (array && array_size > 0) {
                     Bitmap64* new_values = bitmap64_from_int_array(array_size, array);
                     if (new_values) {
-                        const Bitmap64* inputs[2] = {bitmap, new_values};
-                        bitmap64_or(bitmap, 2, inputs);
+                        /* Use _inplace to OR new_values into bitmap */
+                        roaring64_bitmap_or_inplace(bitmap, new_values);
                         bitmap64_free(new_values);
                     }
                     safe_free(array);

--- a/tests/fuzz/fuzz_bitmap_api.c
+++ b/tests/fuzz/fuzz_bitmap_api.c
@@ -122,8 +122,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                     /* Append by creating new bitmap and OR-ing */
                     Bitmap* new_values = bitmap_from_int_array(array_size, array);
                     if (new_values) {
-                        const Bitmap* inputs[2] = {bitmap, new_values};
-                        bitmap_or(bitmap, 2, inputs);
+                        /* Use _inplace to OR new_values into bitmap */
+                        roaring_bitmap_or_inplace(bitmap, new_values);
                         bitmap_free(new_values);
                     }
                     safe_free(array);


### PR DESCRIPTION
## Problem

The fuzzing infrastructure discovered a **heap-use-after-free** bug in the `OP_APPENDINTARRAY` operation of both 32-bit and 64-bit fuzz targets.

### Root Cause

The fuzzer was incorrectly passing the destination bitmap as both:
1. The output parameter to `bitmap_or()`
2. One of the input sources in the inputs array

```c
// BEFORE (buggy):
const Bitmap* inputs[2] = {bitmap, new_values};
bitmap_or(bitmap, 2, inputs);  // bitmap appears in both dst and src!
```

This caused `roaring_bitmap_overwrite()` to free the destination's memory before reading from it (since source[0] == destination), triggering a use-after-free detected by AddressSanitizer.

## Fix

Replace the incorrect multi-input `bitmap_or()` call with the proper `roaring_bitmap_or_inplace()` which safely ORs new values into the existing bitmap without aliasing issues:

```c
// AFTER (correct):
roaring_bitmap_or_inplace(bitmap, new_values);
```

Applied to both:
- `tests/fuzz/fuzz_bitmap_api.c` (32-bit)
- `tests/fuzz/fuzz_bitmap64_api.c` (64-bit)

## Verification

- ✅ Previously crashing input now runs without errors
- ✅ Fuzzer runs successfully with full census1881 corpus
- ✅ No heap-use-after-free detected by AddressSanitizer
- ✅ All fuzz targets build and run cleanly

## Discovery

This bug was found immediately after implementing real census1881 benchmark data as the fuzzing corpus (PR #129). This demonstrates the effectiveness of using real-world data for fuzzing!

## Base Branch

This PR is based on `add-fuzzing-infrastructure` (PR #129) and should be merged after that PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>