### PR TITLE
Automate performance benchmark updates in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,31 @@ jobs:
     needs: [configure, test]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure
       run: ./configure.sh
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Test
       run: ./performance.sh
+    - name: Commit performance results
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add README.md
+        git diff --staged --quiet || git commit -m "Update performance benchmarks [skip ci]"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
   docker:
     name: Build and push to Dockerhub
     needs: [configure, test, performance]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ $ redis-cli
 
 ## Performance
 
-Tested using CRoaring's `census1881` dataset on the travis build [552223545](https://travis-ci.org/aviggiano/redis-roaring/builds/552223545):
+Tested using CRoaring's `census1881` dataset. Performance tests are run automatically on every push to master branch.
 
+<!-- BEGIN_PERFORMANCE -->
 |               OP |     TIME/OP (us) |     ST.DEV. (us) |
 | ---------------- | ---------------- | ---------------- |
 |         R.SETBIT |            19.44 |             4.00 |
@@ -146,3 +147,4 @@ Tested using CRoaring's `census1881` dataset on the travis build [552223545](htt
 |            R.MAX |            19.85 |             0.04 |
 |          R64.MAX |            19.49 |             0.03 |
 |              MAX |            19.94 |             0.06 |
+<!-- END_PERFORMANCE -->

--- a/performance.sh
+++ b/performance.sh
@@ -8,9 +8,34 @@ function performance()
 {
   stop_redis
   start_redis
-  ./build/performance
+
+  # Run performance tests and capture output
+  PERF_OUTPUT=$(./build/performance | grep -E '^\|')
+
   stop_redis
   echo "All performance tests passed"
+
+  # Update README.md with the latest performance results
+  if [ -f "README.md" ] && [ ! -z "$PERF_OUTPUT" ]; then
+    echo "Updating README.md with latest performance results..."
+
+    # Create a temporary file with the new content
+    awk -v perf="$PERF_OUTPUT" '
+      /<!-- BEGIN_PERFORMANCE -->/ {
+        print
+        print perf
+        skip=1
+        next
+      }
+      /<!-- END_PERFORMANCE -->/ {
+        skip=0
+      }
+      !skip
+    ' README.md > README.md.tmp
+
+    mv README.md.tmp README.md
+    echo "README.md updated successfully"
+  fi
 }
 
 setup


### PR DESCRIPTION
Automates performance benchmark updates in README by adding HTML comment markers and updating the performance.sh script to capture and insert test results. The CI workflow now commits and pushes README changes after performance tests run on master branch.

Removes the outdated reference to Travis build 552223545 and ensures the performance benchmarks always reflect the latest test results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)