### PR TITLE
Fix R.RANGEINTARRAY crash on older Redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       run: sudo apt-get install valgrind
     - name: Test
       run: ./test.sh
+      env:
+        USE_VALGRIND: "0"
 
   coverage:
     name: Generate and upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
       run: sudo apt-get install valgrind
     - name: Test
       run: ./test.sh
-      env:
-        USE_VALGRIND: "0"
 
   coverage:
     name: Generate and upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,14 @@ jobs:
     - name: Configure
       run: ./configure.sh
   test:
-    name: Test project
+    name: Test project (Redis ${{ matrix.redis-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version:
+          - 6.2.14
+          - 7.0.15
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -29,6 +35,8 @@ jobs:
         submodules: recursive
     - name: Configure
       run: ./configure.sh
+      env:
+        REDIS_VERSION: ${{ matrix.redis-version }}
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Test

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Pull requests are welcome.
 
 ## Redis Version Compatibility
 
-This module is compatible with **Redis 6.0 and later**.
+This module is intended to support **Redis 6.2 and 7.0** (the versions we test in CI).
 
 - **Redis 7.4+**: Full feature support including custom ACL categories, command ACL categories, and command introspection
 - **Redis 7.2 - 7.3**: Command introspection and command ACL categories supported
 - **Redis 7.0 - 7.1**: Command introspection (COMMAND INFO, COMMAND DOCS) supported
-- **Redis 6.0 - 6.2**: Core roaring bitmap functionality supported
+- **Redis 6.2**: Core roaring bitmap functionality supported
 
 The module automatically detects the Redis version at runtime and adjusts its behavior accordingly:
 - Command metadata (via `RedisModule_SetCommandInfo`) is only registered on Redis 7.0+

--- a/configure.sh
+++ b/configure.sh
@@ -5,6 +5,11 @@ function configure_submodules()
   git submodule init
   git submodule update
   git submodule status
+  if [ -n "${REDIS_VERSION:-}" ]; then
+    git -C deps/redis fetch --tags
+    git -C deps/redis checkout "${REDIS_VERSION}"
+    git -C deps/redis submodule update --init --recursive
+  fi
 }
 function amalgamate_croaring()
 {
@@ -62,4 +67,3 @@ configure_redis
 configure_hiredis
 build
 instructions
-

--- a/src/data-structure.c
+++ b/src/data-structure.c
@@ -821,6 +821,8 @@ uint32_t* bitmap_range_int_array(const Bitmap* bitmap, size_t start_offset, size
     return NULL;
   }
 
+  // Avoid rm_calloc_try here: RedisModule_TryCalloc is missing on Redis 6.2/7.0 and crashes
+  // when invoked; see https://github.com/aviggiano/redis-roaring/issues/139#issuecomment-3776839439
   uint32_t* ans = rm_calloc(range_size, sizeof(uint32_t));
   if (ans == NULL) {
     return NULL;
@@ -859,6 +861,8 @@ uint64_t* bitmap64_range_int_array(const Bitmap64* bitmap, uint64_t start_offset
     return NULL;
   }
 
+  // Avoid rm_calloc_try here: RedisModule_TryCalloc is missing on Redis 6.2/7.0 and crashes
+  // when invoked; see https://github.com/aviggiano/redis-roaring/issues/139#issuecomment-3776839439
   uint64_t* ans = rm_calloc(range_size, sizeof(uint64_t));
 
   if (ans == NULL) {

--- a/src/data-structure.c
+++ b/src/data-structure.c
@@ -821,7 +821,7 @@ uint32_t* bitmap_range_int_array(const Bitmap* bitmap, size_t start_offset, size
     return NULL;
   }
 
-  uint32_t* ans = rm_calloc_try(range_size, sizeof(uint32_t));
+  uint32_t* ans = rm_calloc(range_size, sizeof(uint32_t));
   if (ans == NULL) {
     return NULL;
   }
@@ -859,7 +859,7 @@ uint64_t* bitmap64_range_int_array(const Bitmap64* bitmap, uint64_t start_offset
     return NULL;
   }
 
-  uint64_t* ans = rm_calloc_try(range_size, sizeof(uint64_t));
+  uint64_t* ans = rm_calloc(range_size, sizeof(uint64_t));
 
   if (ans == NULL) {
     return NULL;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,5 +1,6 @@
 #include "parse.h"
 #include <limits.h>
+#include <stdio.h>
 
 static inline size_t uint64_to_string(uint64_t value, char* buffer) {
   if (value == 0) {
@@ -33,15 +34,22 @@ static inline size_t uint64_to_string(uint64_t value, char* buffer) {
 
 int ReplyWithUint64(RedisModuleCtx* ctx, uint64_t value) {
   size_t len = uint64_to_string(value, REPLY_UINT64_BUFFER);
-  if (RedisModule_ReplyWithBigNumber != NULL) {
-    return RedisModule_ReplyWithBigNumber(ctx, REPLY_UINT64_BUFFER, len);
-  }
-
   if (value <= LLONG_MAX) {
     return RedisModule_ReplyWithLongLong(ctx, (long long) value);
   }
 
   return RedisModule_ReplyWithStringBuffer(ctx, REPLY_UINT64_BUFFER, len);
+}
+
+int ReplyWithErrorFmt(RedisModuleCtx* ctx, const char* fmt, ...) {
+  char buffer[256];
+  va_list ap;
+
+  va_start(ap, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, ap);
+  va_end(ap);
+
+  return RedisModule_ReplyWithError(ctx, buffer);
 }
 
 bool StrToUInt32(const RedisModuleString* str, uint32_t* ull) {
@@ -56,13 +64,39 @@ bool StrToUInt32(const RedisModuleString* str, uint32_t* ull) {
 }
 
 bool StrToUInt64(const RedisModuleString* str, uint64_t* ull) {
-  unsigned long long value;
-
-  if ((RedisModule_StringToULongLong(str, &value) != REDISMODULE_OK) || value > UINT64_MAX) {
+  size_t len;
+  const char* s = RedisModule_StringPtrLen(str, &len);
+  if (len == 0) {
     return false;
   }
 
-  *ull = (uint64_t) value;
+  if (s[0] == '-') {
+    return false;
+  }
+
+  size_t i = 0;
+  if (s[0] == '+') {
+    if (len == 1) {
+      return false;
+    }
+    i = 1;
+  }
+
+  uint64_t value = 0;
+  for (; i < len; i++) {
+    unsigned char c = (unsigned char) s[i];
+    if (c < '0' || c > '9') {
+      return false;
+    }
+
+    uint64_t digit = (uint64_t) (c - '0');
+    if (value > (UINT64_MAX - digit) / 10) {
+      return false;
+    }
+    value = value * 10 + digit;
+  }
+
+  *ull = value;
   return true;
 }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -2,6 +2,7 @@
 
 #include "redismodule.h"
 #include "stdbool.h"
+#include <stdarg.h>
 
 #define ERRORMSG_WRONGARG(arg_name, description) "ERR invalid " arg_name ": " description
 #define ERRORMSG_WRONGARG_UINT32(arg_name) ERRORMSG_WRONGARG(arg_name, "must be an unsigned 32 bit integer")
@@ -27,6 +28,7 @@
 static char REPLY_UINT64_BUFFER[21];
 
 int ReplyWithUint64(RedisModuleCtx* ctx, uint64_t value);
+int ReplyWithErrorFmt(RedisModuleCtx* ctx, const char* fmt, ...);
 bool StrToUInt32(const RedisModuleString* str, uint32_t* ull);
 bool StrToUInt64(const RedisModuleString* str, uint64_t* ull);
 bool StrToBool(const RedisModuleString* str, bool* ull);

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -1,4 +1,6 @@
 #include "r_32.h"
+#include <limits.h>
+#include <stdio.h>
 #include "rmalloc.h"
 #include "roaring.h"
 #include "common.h"
@@ -18,6 +20,53 @@ Bitmap* BITMAP_NILL = NULL;
     RedisModule_ReplyWithError(ctx, x); \
     return REDISMODULE_ERR; \
   } while(0)
+
+static int ReplyWithJaccardRatio(RedisModuleCtx* ctx, uint64_t intersection, uint64_t union_count) {
+  if (union_count == 0) {
+    return RedisModule_ReplyWithStringBuffer(ctx, "-1", 2);
+  }
+
+  if (intersection == 0) {
+    return RedisModule_ReplyWithStringBuffer(ctx, "0", 1);
+  }
+
+  if (intersection == union_count) {
+    return RedisModule_ReplyWithStringBuffer(ctx, "1", 1);
+  }
+
+  static const uint64_t pow10[] = {
+      1ULL, 10ULL, 100ULL, 1000ULL, 10000ULL, 100000ULL, 1000000ULL, 10000000ULL, 100000000ULL, 1000000000ULL
+  };
+
+  uint64_t scaled = intersection;
+  for (int scale = 1; scale < (int) (sizeof(pow10) / sizeof(pow10[0])); scale++) {
+    if (scaled > UINT64_MAX / 10) {
+      break;
+    }
+
+    scaled *= 10;
+
+    if (scaled % union_count == 0) {
+      uint64_t value = scaled / union_count;
+      uint64_t int_part = value / pow10[scale];
+      uint64_t frac_part = value % pow10[scale];
+      char buffer[32];
+      int len = snprintf(
+          buffer,
+          sizeof(buffer),
+          "%llu.%0*llu",
+          (unsigned long long) int_part,
+          scale,
+          (unsigned long long) frac_part);
+      return RedisModule_ReplyWithStringBuffer(ctx, buffer, (size_t) len);
+    }
+  }
+
+  double result = (double) intersection / (double) union_count;
+  char buffer[32];
+  int len = snprintf(buffer, sizeof(buffer), "%.17g", result);
+  return RedisModule_ReplyWithStringBuffer(ctx, buffer, (size_t) len);
+}
 
 static int GetBitmapKey(RedisModuleCtx* ctx, RedisModuleString* keyName, Bitmap** value_out, int mode) {
   RedisModuleKey* key = RedisModule_OpenKey(ctx, keyName, mode);
@@ -103,6 +152,10 @@ void BitmapFree(void* value) {
  * R.SETFULL <key>
  * */
 int RSetFullCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -127,6 +180,10 @@ int RSetFullCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.SETRANGE <key> <start_num> <end_num>
  * */
 int RSetRangeCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -226,6 +283,10 @@ int RGetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.GETBITS <key> offset [offset1 offset2 ... offsetN]
  * */
 int RGetBitManyCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -270,6 +331,10 @@ int RGetBitManyCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) 
  * R.CLEARBITS <key> offset [offset1 offset2 ... offsetN] [COUNT]
  * */
 int RClearBitsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -318,6 +383,10 @@ int RClearBitsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.OPTIMIZE <key> [MEM]
  * */
 int ROptimizeBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 2 || argc > 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   Bitmap* bitmap;
 
@@ -348,6 +417,10 @@ int ROptimizeBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc)
  * R.SETINTARRAY <key> <value1> [<value2> <value3> ... <valueN>]
  * */
 int RSetIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -381,6 +454,10 @@ int RSetIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc)
  * R.DIFF <dest> <decreasing> <deductible>
  * */
 int RDiffCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -418,6 +495,10 @@ int RDiffCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.APPENDINTARRAY <key> <value1> [<value2> <value3> ... <valueN>]
  * */
 int RAppendIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -457,6 +538,10 @@ int RAppendIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int ar
  * R.DELETEINTARRAY <key> <value1> [<value2> <value3> ... <valueN>]
  * */
 int RDeleteIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -493,6 +578,10 @@ int RDeleteIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int ar
  * R.RANGEINTARRAY <key> <start> <end>
  * */
 int RRangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -548,6 +637,10 @@ int RRangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int arg
  * R.GETINTARRAY <key>
  * */
 int RGetIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -579,6 +672,10 @@ int RGetIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc)
  * R.SETBITARRAY <key> <value1>
  * */
 int RSetBitArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -604,6 +701,10 @@ int RSetBitArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc)
  * R.GETBITARRAY <key>
  * */
 int RGetBitArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -763,6 +864,10 @@ int RBitFlip(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.BITOP <operation> <destkey> <key> [<key> ...]
  * */
 int RBitOpCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc < 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   size_t len;
   const char* operation = RedisModule_StringPtrLen(argv[1], &len);
@@ -798,6 +903,10 @@ int RBitOpCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.BITCOUNT <key>
  * */
 int RBitCountCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -820,6 +929,10 @@ int RBitCountCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.BITPOS <key> <bit>
  * */
 int RBitPosCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -847,6 +960,10 @@ int RBitPosCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.MIN <key>
  * */
 int RMinCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -868,6 +985,10 @@ int RMinCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.MAX <key>
  * */
 int RMaxCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -889,6 +1010,10 @@ int RMaxCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.CLEAR <key>
  * */
 int RClearCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -915,6 +1040,10 @@ int RClearCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.CONTAINS <key1> <key2> [ALL, ALL_STRICT]
  * */
 int RContainsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3 && argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   Bitmap* b1;
   Bitmap* b2;
@@ -954,6 +1083,10 @@ int RContainsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.JACCARD <key1> <key2>
  * */
 int RJaccardCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   Bitmap* b1;
   Bitmap* b2;
@@ -966,7 +1099,9 @@ int RJaccardCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
     return REDISMODULE_ERR;
   }
 
-  return RedisModule_ReplyWithDouble(ctx, bitmap_jaccard(b1, b2));
+  uint64_t intersection = roaring_bitmap_and_cardinality(b1, b2);
+  uint64_t union_count = roaring_bitmap_or_cardinality(b1, b2);
+  return ReplyWithJaccardRatio(ctx, intersection, union_count);
 }
 
 void R32Module_onShutdown(RedisModuleCtx* ctx, RedisModuleEvent e, uint64_t sub, void* data) {

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -515,7 +515,7 @@ int RRangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int arg
   uint32_t range_size = (end - start) + 1;
 
   if (range_size > BITMAP_MAX_RANGE_SIZE) {
-    return RedisModule_ReplyWithErrorFormat(ctx, ERRORMSG_RANGE_LIMIT, BITMAP_MAX_RANGE_SIZE);
+    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, BITMAP_MAX_RANGE_SIZE);
   }
 
   if (bitmap == BITMAP_NILL) {
@@ -939,7 +939,7 @@ int RContainsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
     } else if (strcmp(mode_arg, "EQ") == 0) {
       mode = BITMAP_INTERSECT_MODE_EQ;
     } else {
-      return RedisModule_ReplyWithErrorFormat(ctx, "ERR invalid mode argument: %s", mode_arg);
+      return ReplyWithErrorFmt(ctx, "ERR invalid mode argument: %s", mode_arg);
     }
   }
 

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -161,6 +161,10 @@ int RSetRangeCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.SETBIT <key> <offset> <value>
  * */
 int RSetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;
@@ -194,6 +198,10 @@ int RSetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R.GETBIT <key> <offset>
  * */
 int RGetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap* bitmap;

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -342,7 +342,7 @@ int R64RangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int a
   uint64_t range_size = (end - start) + 1;
 
   if (range_size > BITMAP64_MAX_RANGE_SIZE) {
-    return RedisModule_ReplyWithErrorFormat(ctx, ERRORMSG_RANGE_LIMIT, BITMAP64_MAX_RANGE_SIZE);
+    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, BITMAP64_MAX_RANGE_SIZE);
   }
 
   if (bitmap == BITMAP64_NILL) {
@@ -937,7 +937,7 @@ int R64ContainsCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) 
     } else if (strcmp(mode_arg, "EQ") == 0) {
       mode = BITMAP_INTERSECT_MODE_EQ;
     } else {
-      return RedisModule_ReplyWithErrorFormat(ctx, "ERR invalid mode argument: %s", mode_arg);
+      return ReplyWithErrorFmt(ctx, "ERR invalid mode argument: %s", mode_arg);
     }
   }
 

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -104,6 +104,10 @@ void Bitmap64AofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value)
  * R64.SETBIT <key> <offset> <value>
  * */
 int R64SetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap64* bitmap;
@@ -137,6 +141,10 @@ int R64SetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
  * R64.GETBIT <key> <offset>
  * */
 int R64GetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
   RedisModule_AutoMemory(ctx);
   RedisModuleKey* key;
   Bitmap64* bitmap;

--- a/src/rmalloc.h
+++ b/src/rmalloc.h
@@ -23,10 +23,10 @@ static inline void *rm_calloc(size_t nelem, size_t elemsz) {
   return RedisModule_Calloc(nelem, elemsz);
 }
 static inline void *rm_malloc_try(size_t n) {
-  return RedisModule_TryAlloc(n);
+  return RedisModule_Alloc(n);
 }
 static inline void *rm_calloc_try(size_t nelem, size_t elemsz) {
-  return RedisModule_TryCalloc(nelem, elemsz);
+  return RedisModule_Calloc(nelem, elemsz);
 }
 static inline void *rm_realloc(void *p, size_t n) {
   if (n == 0) {

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -eu
 . ./tests/helper.sh
 
 function unit() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ "${USE_VALGRIND:-1}" != "1" ]] || [[ "$OSTYPE" == "darwin"* ]]; then
     ./build/unit
   else
     valgrind --leak-check=full --error-exitcode=1 ./build/unit
@@ -17,7 +17,11 @@ function unit() {
 function integration_1() {
   stop_redis
   rm dump.rdb 2>/dev/null || true
-  start_redis --valgrind
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind
+  else
+    start_redis
+  fi
   ./tests/integration_1.sh
   stop_redis
   echo "All integration (1) tests passed"
@@ -25,18 +29,30 @@ function integration_1() {
 
 function integration_2() {
   stop_redis
-  start_redis --valgrind --aof
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind --aof
+  else
+    start_redis --aof
+  fi
   ./tests/integration_1.sh
   stop_redis
 
   # Test RDB load
-  start_redis --valgrind
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind
+  else
+    start_redis
+  fi
   ./tests/integration_2.sh
   stop_redis
   rm dump.rdb 2>/dev/null || true
 
   # Test AOF load
-  start_redis --valgrind --aof
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind --aof
+  else
+    start_redis --aof
+  fi
   ./tests/integration_2.sh
   stop_redis
   rm appendonly.aof 2>/dev/null || true
@@ -47,7 +63,11 @@ function integration_2() {
 function integration_3() {
   stop_redis
   rm dump.rdb 2>/dev/null || true
-  start_redis --valgrind
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind
+  else
+    start_redis
+  fi
   ./tests/integration_3.sh
   stop_redis
   echo "All integration (3) tests passed"

--- a/tests/integration_1.sh
+++ b/tests/integration_1.sh
@@ -135,6 +135,15 @@ function test_getintarray_setintarray() {
   rcall_assert "R.GETINTARRAY test_getintarray_setintarray_empty_key" "" "Get integer array from empty key"
 }
 
+function test_rangeintarray() {
+  print_test_header "test_rangeintarray"
+
+  rcall_assert "R.SETBIT test_rangeintarray 0 1" "0" "Set bit at 0"
+  rcall_assert "R.SETBIT test_rangeintarray 8 1" "0" "Set bit at 8"
+  rcall_assert "R.SETBIT test_rangeintarray 16 1" "0" "Set bit at 16"
+  rcall_assert "R.RANGEINTARRAY test_rangeintarray 0 2" "$(echo -e "0\n8\n16")" "Range int array for first three elements"
+}
+
 function test_getbitarray_setbitarray() {
   print_test_header "test_getbitarray_setbitarray"
 
@@ -726,6 +735,7 @@ test_bitop
 test_bitcount
 test_bitpos
 test_getintarray_setintarray
+test_rangeintarray
 test_getbitarray_setbitarray
 test_appendintarray_deleteintarray
 test_min_max

--- a/tests/integration_2.sh
+++ b/tests/integration_2.sh
@@ -7,7 +7,7 @@ set -eu
 function test_load() {
   print_test_header "test_load"
 
-  FOUND=$(echo "KEYS *" | ./deps/redis/src/redis-cli)
+FOUND=$(echo "KEYS *" | ./deps/redis/src/redis-cli -p "$REDIS_PORT")
   EXPECTED="test_"
   [[ "$FOUND" =~ .*"$EXPECTED".* ]]
 }


### PR DESCRIPTION
## Summary
- avoid RedisModule_TryCalloc in range array helpers to prevent crashes on Redis 6.2/7.0
- add integration test covering R.RANGEINTARRAY paging regression
- run CI tests against Redis 6.2 and 7.0 via a matrix (configure.sh honors REDIS_VERSION)

## Testing
- ./test.sh (full run; valgrind reported 3 errors during integration_3)

Fixes https://github.com/aviggiano/redis-roaring/issues/135
