### PR TITLE
[codex] Add redis-roaring bitmap migrator tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
         submodules: recursive
     - name: Validate manifest
       run: python3 ./scripts/validate_fuzz_manifest.py
+
+  migrator:
+    name: Validate bitmap migrator
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Compile migrator
+      run: python3 -m py_compile tools/redis-bitmap-migrate.py tests/integration/redis-bitmap-migrate.py
+    - name: Run migrator contract tests
+      run: python3 tests/integration/redis-bitmap-migrate.py
+
   test:
     if: github.event_name != 'schedule'
     name: Test project (Redis ${{ matrix.redis-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,33 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Checkout native Redis
+      uses: actions/checkout@v2
+      with:
+        repository: aviggiano/redis
+        ref: unstable
+        path: native-redis
+        submodules: recursive
     - name: Compile migrator
       run: python3 -m py_compile tools/redis-bitmap-migrate.py tests/integration/redis-bitmap-migrate.py
     - name: Run migrator contract tests
       run: python3 tests/integration/redis-bitmap-migrate.py
+    - name: Build native Redis unstable
+      run: make -C native-redis -j"$(nproc)"
+    - name: Build redis-roaring module
+      run: |
+        cd src
+        ../deps/CRoaring/amalgamation.sh
+        cd ..
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --target redis-roaring -- -j"$(nproc)"
+    - name: Run real redis-roaring to native Redis migration tests
+      env:
+        REDIS_DOWNLOAD_CROARING_REALDATA: "1"
+        REDIS_NATIVE_SERVER: ${{ github.workspace }}/native-redis/src/redis-server
+        REDIS_ROARING_MODULE: ${{ github.workspace }}/build/libredis-roaring.so
+        REDIS_ROARING_SERVER: ${{ github.workspace }}/native-redis/src/redis-server
+      run: python3 tests/integration/redis-bitmap-migrate.py RealRedisRoaringMigrationTests
 
   test:
     if: github.event_name != 'schedule'

--- a/README.md
+++ b/README.md
@@ -57,6 +57,47 @@ docker run -p 6379:6379 aviggiano/redis-roaring:latest
 Run the `test.sh` script for unit tests, integration tests and performance tests.
 The performance tests can take a while, since they run on a real dataset of integer values.
 
+## Migrating to Redis native bitmaps
+
+The standalone `tools/redis-bitmap-migrate.py` utility migrates `R.*` and
+`R64.*` redis-roaring keys into Redis native bitmap values through public Redis
+and redis-roaring commands. It streams integer ranges from the source, writes
+native bitmap values on the target, validates temporary keys, and records a
+durable JSON manifest. It does not depend on Redis core internals or
+redis-roaring private payload layouts.
+
+By default the tool performs a dry run:
+
+```bash
+python3 tools/redis-bitmap-migrate.py \
+  --source-host 127.0.0.1 --source-port 6379 \
+  --target-host 127.0.0.1 --target-port 6380 \
+  --manifest redis-bitmap-migrate-manifest.json
+```
+
+To write destination keys, run a final pass while source writes are frozen and
+acknowledge that with `--apply --assume-frozen`.
+
+```bash
+python3 tools/redis-bitmap-migrate.py \
+  --source-host 127.0.0.1 --source-port 6379 \
+  --target-host 127.0.0.1 --target-port 6380 \
+  --manifest redis-bitmap-migrate-manifest.json \
+  --apply --assume-frozen
+```
+
+Run the migrator contract tests with:
+
+```bash
+python3 -m py_compile tools/redis-bitmap-migrate.py tests/integration/redis-bitmap-migrate.py
+python3 tests/integration/redis-bitmap-migrate.py
+```
+
+The default test run uses fake RESP servers to verify the public-command
+contract. Real Redis-to-native integration tests are enabled when
+`REDIS_NATIVE_SERVER`, `REDIS_ROARING_SERVER`, and `REDIS_ROARING_MODULE` point
+to built binaries.
+
 ## Fuzzing
 
 redis-roaring includes fuzz testing using libFuzzer with AddressSanitizer and UndefinedBehaviorSanitizer. Five fuzz targets cover 32-bit operations, 64-bit operations, complex bitwise operations, data parsing, and BITOP key-discovery metadata. Fuzzing runs automatically on every push to master.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ The performance tests can take a while, since they run on a real dataset of inte
 
 ## Migrating to Redis native bitmaps
 
+After [redis/redis#15296](https://github.com/redis/redis/issues/15296),
+core Redis supports native Roaring-backed bitmaps. We recommend migrating
+redis-roaring keys to core Redis for long-term upstream support, standard Redis
+persistence and replication behavior, and simpler operational tooling.
+
 The standalone `tools/redis-bitmap-migrate.py` utility migrates `R.*` and
 `R64.*` redis-roaring keys into Redis native bitmap values through public Redis
 and redis-roaring commands. It streams integer ranges from the source, writes

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -1,0 +1,1085 @@
+#!/usr/bin/env python3
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import re
+import socket
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import warnings
+from pathlib import Path
+from urllib.request import urlretrieve
+from zipfile import ZipFile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_PATH = REPO_ROOT / "tools" / "redis-bitmap-migrate.py"
+MODULE_NAME = "redis_bitmap_migrate_under_test"
+REALDATA_BASE_URL = "https://raw.githubusercontent.com/RoaringBitmap/real-roaring-datasets/master"
+INTEGER_RE = re.compile(r"\d+")
+
+spec = importlib.util.spec_from_file_location(MODULE_NAME, TOOL_PATH)
+migrate = importlib.util.module_from_spec(spec)
+sys.modules[MODULE_NAME] = migrate
+spec.loader.exec_module(migrate)
+
+
+def encode_resp(value):
+    if isinstance(value, bytes):
+        return b"$%d\r\n%s\r\n" % (len(value), value)
+    if isinstance(value, str):
+        data = value.encode()
+        return b"+%s\r\n" % data
+    if isinstance(value, int):
+        return b":%d\r\n" % value
+    if value is None:
+        return b"$-1\r\n"
+    if isinstance(value, list):
+        return b"*%d\r\n" % len(value) + b"".join(encode_resp(item) for item in value)
+    raise TypeError(value)
+
+
+def read_resp_command(fp):
+    line = fp.readline()
+    if not line:
+        return None
+    if not line.startswith(b"*"):
+        raise AssertionError(f"expected RESP array, got {line!r}")
+    count = int(line[1:-2])
+    command = []
+    for _ in range(count):
+        bulk = fp.readline()
+        if not bulk.startswith(b"$"):
+            raise AssertionError(f"expected RESP bulk, got {bulk!r}")
+        size = int(bulk[1:-2])
+        data = fp.read(size)
+        if fp.read(2) != b"\r\n":
+            raise AssertionError("bulk did not end with CRLF")
+        command.append(data)
+    return command
+
+
+class FakeRedisServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(
+        self,
+        mode,
+        *args,
+        source_type="reroaring",
+        bits=None,
+        expire_at_ms=None,
+        mutate_after_range=False,
+    ):
+        self.mode = mode
+        self.source_type = source_type
+        if bits is None:
+            self.bits = {b"foo": {1, 2, 5, 100}}
+        elif isinstance(bits, dict):
+            self.bits = {
+                key if isinstance(key, bytes) else str(key).encode("utf-8"): set(values)
+                for key, values in bits.items()
+            }
+        else:
+            self.bits = {b"foo": set(bits)}
+        if expire_at_ms is None:
+            self.source_expire_at_ms = {}
+        elif isinstance(expire_at_ms, dict):
+            self.source_expire_at_ms = {
+                key if isinstance(key, bytes) else str(key).encode("utf-8"): int(value)
+                for key, value in expire_at_ms.items()
+            }
+        else:
+            self.source_expire_at_ms = {key: int(expire_at_ms) for key in self.bits}
+        self.mutate_after_range = mutate_after_range
+        self.mutated_range_keys = set()
+        self.target = {}
+        self.target_byte_len = {}
+        self.target_expire_at_ms = {}
+        self.target_dump_payloads = {}
+        self.target_dump_counter = 0
+        self.commands = []
+        super().__init__(*args)
+
+
+class FakeRedisHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        fp = self.request.makefile("rb")
+        while True:
+            command = read_resp_command(fp)
+            if command is None:
+                return
+            self.server.commands.append(command)
+            try:
+                reply = self.dispatch(command)
+            except Exception as exc:
+                self.request.sendall(b"-ERR " + str(exc).encode() + b"\r\n")
+                continue
+            self.request.sendall(encode_resp(reply))
+
+    def dispatch(self, command):
+        name = command[0].upper()
+        if name == b"PING":
+            return "PONG"
+        if name == b"SELECT":
+            return "OK"
+        if name == b"INFO":
+            return b"# Cluster\r\ncluster_enabled:0\r\n"
+        if self.server.mode == "source":
+            return self.source(command, name)
+        return self.target(command, name)
+
+    def source(self, command, name):
+        key = command[1] if len(command) > 1 else b""
+        if name == b"SCAN":
+            return [b"0", list(self.server.bits)]
+        if name == b"EXISTS":
+            return 1 if key in self.server.bits else 0
+        if name.startswith(b"R64.") and self.server.source_type != "roaring64":
+            raise RuntimeError("WRONGTYPE")
+        if name.startswith(b"R.") and self.server.source_type != "reroaring":
+            raise RuntimeError("WRONGTYPE")
+        if name in {b"R.BITCOUNT", b"R64.BITCOUNT"}:
+            return len(self.server.bits[key])
+        if name in {b"R.MIN", b"R64.MIN"}:
+            values = self.server.bits[key]
+            return min(values) if values else -1
+        if name in {b"R.MAX", b"R64.MAX"}:
+            values = self.server.bits[key]
+            return max(values) if values else -1
+        if name == b"PEXPIRETIME":
+            return self.server.source_expire_at_ms.get(key, -1)
+        if name == b"DUMP":
+            return b"source-payload"
+        if name in {b"R.RANGEINTARRAY", b"R64.RANGEINTARRAY"}:
+            values = sorted(self.server.bits[key])
+            start = int(command[2])
+            end = int(command[3])
+            reply = values[start:end + 1]
+            if self.server.mutate_after_range and key not in self.server.mutated_range_keys:
+                next_offset = max(values) + 1 if values else 0
+                self.server.bits[key].add(next_offset)
+                self.server.mutated_range_keys.add(key)
+            return reply
+        raise RuntimeError(f"unknown source command {name.decode()}")
+
+    def target(self, command, name):
+        key = command[1] if len(command) > 1 else b""
+        if name == b"EXISTS":
+            return 1 if key in self.server.target else 0
+        if name == b"DEL":
+            deleted = 0
+            for item in command[1:]:
+                if item in self.server.target:
+                    deleted += 1
+                    del self.server.target[item]
+                    self.server.target_byte_len.pop(item, None)
+                    self.server.target_expire_at_ms.pop(item, None)
+            return deleted
+        if name == b"SET":
+            value = command[2]
+            self.server.target[key] = {
+                bit
+                for byte_index, byte in enumerate(value)
+                for bit_index in range(8)
+                if byte & (1 << (7 - bit_index))
+                for bit in [byte_index * 8 + bit_index]
+            }
+            self.server.target_byte_len[key] = len(value)
+            self.server.target_expire_at_ms.pop(key, None)
+            return "OK"
+        if name == b"SETBIT":
+            offset = int(command[2])
+            value = int(command[3])
+            bits = self.server.target.setdefault(key, set())
+            old = 1 if offset in bits else 0
+            self.server.target_byte_len[key] = max(
+                self.target_byte_len(key),
+                offset // 8 + 1,
+            )
+            if value:
+                bits.add(offset)
+            else:
+                bits.discard(offset)
+            return old
+        if name == b"BITMAP":
+            return "OK"
+        if name == b"DUMP":
+            bits = sorted(self.server.target[key])
+            self.server.target_dump_counter += 1
+            payload = b"fake-target-dump:%d" % self.server.target_dump_counter
+            self.server.target_dump_payloads[payload] = (set(bits), self.target_byte_len(key))
+            return payload
+        if name == b"RESTORE":
+            ttl = int(command[2])
+            payload = command[3]
+            try:
+                bits, byte_len = self.server.target_dump_payloads[payload]
+            except KeyError as exc:
+                raise RuntimeError("invalid target DUMP payload") from exc
+            self.server.target[key] = set(bits)
+            self.server.target_byte_len[key] = byte_len
+            options = {part.upper() for part in command[4:]}
+            if ttl > 0 and b"ABSTTL" in options:
+                self.server.target_expire_at_ms[key] = ttl
+            elif ttl > 0:
+                self.server.target_expire_at_ms[key] = migrate.now_ms() + ttl
+            else:
+                self.server.target_expire_at_ms.pop(key, None)
+            return "OK"
+        if name == b"TYPE":
+            return "bitmap" if key in self.server.target else "none"
+        if name == b"BITCOUNT":
+            return len(self.server.target[key])
+        if name == b"BITPOS":
+            bit = int(command[2])
+            bits = self.server.target[key]
+            if bit == 1:
+                return min(bits) if bits else -1
+            for offset in range(self.target_byte_len(key) * 8):
+                if offset not in bits:
+                    return offset
+            return -1
+        if name == b"GETBIT":
+            return 1 if int(command[2]) in self.server.target.get(key, set()) else 0
+        if name == b"PTTL":
+            if key not in self.server.target:
+                return -2
+            expire_at = self.server.target_expire_at_ms.get(key)
+            if expire_at is None:
+                return -1
+            return max(expire_at - migrate.now_ms(), 0)
+        if name == b"RENAME":
+            source, destination = command[1], command[2]
+            source_byte_len = self.target_byte_len(source)
+            source_expire_at = self.server.target_expire_at_ms.pop(source, None)
+            self.server.target[destination] = self.server.target.pop(source)
+            self.server.target_byte_len.pop(destination, None)
+            self.server.target_expire_at_ms.pop(destination, None)
+            self.server.target_byte_len[destination] = self.server.target_byte_len.pop(
+                source,
+                source_byte_len,
+            )
+            if source_expire_at is not None:
+                self.server.target_expire_at_ms[destination] = source_expire_at
+            return "OK"
+        if name == b"RENAMENX":
+            source, destination = command[1], command[2]
+            if destination in self.server.target:
+                return 0
+            source_byte_len = self.target_byte_len(source)
+            source_expire_at = self.server.target_expire_at_ms.pop(source, None)
+            self.server.target[destination] = self.server.target.pop(source)
+            self.server.target_byte_len[destination] = self.server.target_byte_len.pop(
+                source,
+                source_byte_len,
+            )
+            if source_expire_at is not None:
+                self.server.target_expire_at_ms[destination] = source_expire_at
+            return 1
+        raise RuntimeError(f"unknown target command {name.decode()}")
+
+    def target_byte_len(self, key):
+        if key in self.server.target_byte_len:
+            return self.server.target_byte_len[key]
+        bits = self.server.target.get(key, set())
+        return max(bits) // 8 + 1 if bits else 0
+
+
+class ServerPair:
+    def __init__(
+        self,
+        source_type="reroaring",
+        bits=None,
+        expire_at_ms=None,
+        mutate_after_range=False,
+    ):
+        self.source = FakeRedisServer(
+            "source",
+            ("127.0.0.1", 0),
+            FakeRedisHandler,
+            source_type=source_type,
+            bits=bits,
+            expire_at_ms=expire_at_ms,
+            mutate_after_range=mutate_after_range,
+        )
+        self.target = FakeRedisServer("target", ("127.0.0.1", 0), FakeRedisHandler)
+        self.threads = [
+            threading.Thread(target=self.source.serve_forever, daemon=True),
+            threading.Thread(target=self.target.serve_forever, daemon=True),
+        ]
+
+    def __enter__(self):
+        for thread in self.threads:
+            thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.source.shutdown()
+        self.target.shutdown()
+        self.source.server_close()
+        self.target.server_close()
+
+    @property
+    def source_port(self):
+        return self.source.server_address[1]
+
+    @property
+    def target_port(self):
+        return self.target.server_address[1]
+
+    def args(self, manifest, *extra):
+        return [
+            "--source-host", "127.0.0.1",
+            "--source-port", str(self.source_port),
+            "--target-host", "127.0.0.1",
+            "--target-port", str(self.target_port),
+            "--manifest", str(manifest),
+            *extra,
+        ]
+
+
+class RedisBitmapMigrateTests(unittest.TestCase):
+    def run_migrator(self, args):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", ResourceWarning)
+                rc = migrate.main(args)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_apply_migrates_reroaring_key(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5, 100}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "2")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=4", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {1, 2, 5, 100})
+            self.assertFalse(any(key.endswith(b":build") or key.endswith(b":tmp") for key in servers.target.target))
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "committed")
+            self.assertEqual(data["entries"][0]["cardinality"], 4)
+            self.assertEqual(data["entries"][0]["validation"]["type"], "bitmap")
+
+    def test_apply_preserves_empty_source_as_empty_native_bitmap(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits=set()) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "2")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=0", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], set())
+            self.assertEqual(servers.target.target_byte_len[b"foo"], 0)
+
+            target = migrate.RedisClient(migrate.RedisEndpoint(
+                "127.0.0.1",
+                servers.target_port,
+                0,
+                None,
+                None,
+                1.0,
+                "target",
+            ))
+            self.assertEqual(target.execute(["BITPOS", "foo", "0"]), -1)
+            self.assertEqual(target.execute(["BITPOS", "foo", "1"]), -1)
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "committed")
+            self.assertEqual(data["entries"][0]["cardinality"], 0)
+            self.assertEqual(data["entries"][0]["validation"]["bitpos_0"], -1)
+            self.assertEqual(data["entries"][0]["validation"]["bitpos_1"], -1)
+
+    def test_apply_restores_absolute_ttl(self):
+        expire_at = migrate.now_ms() + 60000
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={7, 9}, expire_at_ms=expire_at) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {7, 9})
+            self.assertEqual(servers.target.target_expire_at_ms[b"foo"], expire_at)
+
+            restore_commands = [
+                command for command in servers.target.commands
+                if command and command[0].upper() == b"RESTORE"
+            ]
+            self.assertEqual(len(restore_commands), 1)
+            self.assertEqual(restore_commands[0][2], str(expire_at).encode())
+            self.assertIn(b"ABSTTL", [part.upper() for part in restore_commands[0]])
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["expire_at_ms"], expire_at)
+            self.assertGreater(data["entries"][0]["validation"]["ttl_ms"], 0)
+
+    def test_dry_run_records_plan_without_target_writes(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={3, 9}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(servers.args(manifest, "--key", "foo"))
+
+            self.assertEqual(rc, 0)
+            self.assertIn("DRY-RUN db=0 key=foo type=reroaring count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target, {})
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "dry_run")
+            self.assertEqual(data["entries"][0]["cardinality"], 2)
+
+    def test_apply_uses_requested_db_for_source_and_target(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={3, 9}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--db", "2", "--key", "foo", "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=2 key=foo count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {3, 9})
+            self.assertIn([b"SELECT", b"2"], servers.source.commands)
+            self.assertIn([b"SELECT", b"2"], servers.target.commands)
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["db"], 2)
+
+    def test_key_file_accepts_binary_key_names(self):
+        key = b"bitmap:\xff native"
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={key: {4, 12}}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            key_file = Path(tmp) / "keys.txt"
+            key_file.write_bytes(key + b"\n")
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--key-file", str(key_file), "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[key], {4, 12})
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["key_b64"], migrate.key_to_b64(key))
+            self.assertEqual(data["entries"][0]["destination_key_b64"], migrate.key_to_b64(key))
+
+    def test_roaring64_above_cap_fails_by_default(self):
+        wide = migrate.NATIVE_V1_MAX_BIT + 1
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(source_type="roaring64", bits={wide}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(servers.args(manifest, "--source-type", "auto"))
+
+            self.assertEqual(rc, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("FAILED db=0 key=foo", stderr)
+            self.assertIn("exceeds v1 native bitmap cap", stderr)
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "failed")
+            self.assertIn(str(wide), data["entries"][0]["error"])
+
+    def test_roaring64_above_cap_can_skip_loudly(self):
+        wide = migrate.NATIVE_V1_MAX_BIT + 1
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(source_type="roaring64", bits={wide}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(servers.args(manifest, "--cap-policy", "skip"))
+
+            self.assertEqual(rc, 0)
+            self.assertIn("skipped=1", stdout)
+            self.assertIn("SKIP db=0 key=foo", stderr)
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "skipped")
+            self.assertEqual(data["entries"][0]["cap_policy"], "skip")
+            self.assertIn(str(wide), data["entries"][0]["error"])
+
+    def test_apply_without_replace_preserves_existing_destination_and_fails(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            servers.target.target[b"foo"] = {77}
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("FAILED db=0 key=foo", stderr)
+            self.assertIn("destination key already exists", stderr)
+            self.assertEqual(servers.target.target[b"foo"], {77})
+            self.assertFalse(any(key.endswith(b":build") or key.endswith(b":tmp") for key in servers.target.target))
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "failed")
+            self.assertEqual(data["entries"][0]["overwrite_policy"], "no-overwrite")
+            self.assertIn("destination key already exists", data["entries"][0]["error"])
+
+    def test_apply_replace_overwrites_existing_destination(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            servers.target.target[b"foo"] = {77}
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen", "--replace")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=3", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {1, 2, 5})
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "committed")
+            self.assertEqual(data["entries"][0]["overwrite_policy"], "replace")
+
+    def test_source_cardinality_change_during_export_fails(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5, 100}, mutate_after_range=True) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "2")
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("source cardinality changed during export", stderr)
+            self.assertNotIn(b"foo", servers.target.target)
+
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "failed")
+            self.assertIn("source cardinality changed during export", data["entries"][0]["error"])
+
+    def test_resume_imported_temp_key_commits_without_reexport(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5, 100}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            key = b"foo"
+            entry_id = "db0:" + hashlib.sha256(key).hexdigest()
+            digest = hashlib.sha256(b"0:" + key).hexdigest().encode("ascii")
+            temp_key = b"__redis-bitmap-migrate:" + digest + b":tmp"
+            servers.target.target[temp_key] = {1, 2, 5, 100}
+
+            manifest.write_text(json.dumps({
+                "version": migrate.MANIFEST_VERSION,
+                "created_at_ms": 1,
+                "updated_at_ms": 1,
+                "tool": "redis-bitmap-migrate",
+                "options": {},
+                "entries": [{
+                    "id": entry_id,
+                    "state": "imported",
+                    "db": 0,
+                    "key": "foo",
+                    "key_b64": "Zm9v",
+                    "sample_offsets": [1, 100],
+                    "full_diff_offsets": [1, 2, 5, 100],
+                }],
+            }))
+
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--resume", "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("RESUMED db=0 key=foo from temporary key", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {1, 2, 5, 100})
+            self.assertNotIn(temp_key, servers.target.target)
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "committed")
+
+
+def free_tcp_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def redis_roaring_server_path():
+    return Path(os.environ.get("REDIS_ROARING_SERVER", REPO_ROOT / "deps" / "redis" / "src" / "redis-server"))
+
+
+def native_redis_server_path():
+    raw = os.environ.get("REDIS_NATIVE_SERVER") or os.environ.get("REDIS_SERVER")
+    return Path(raw) if raw else None
+
+
+def redis_roaring_module_path():
+    raw = os.environ.get("REDIS_ROARING_MODULE")
+    if raw:
+        return Path(raw)
+    return REPO_ROOT / "build" / "libredis-roaring.so"
+
+
+def env_truthy(name):
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def croaring_realdata_dir():
+    return Path(os.environ.get("REDIS_CROARING_REALDATA_DIR", REPO_ROOT.parent / "croaring-realdata"))
+
+
+def parse_realdata_text(text, max_values):
+    bits = []
+    for match in INTEGER_RE.finditer(text):
+        bits.append(int(match.group(0)))
+        if len(bits) >= max_values:
+            break
+    return bits
+
+
+def load_census1881_realdata_bits(max_values=4096, min_values=128):
+    realdata_path = croaring_realdata_dir()
+    candidates = []
+    if realdata_path.is_file():
+        candidates.append(realdata_path)
+    elif realdata_path.is_dir():
+        archive = realdata_path / "census1881.zip"
+        if archive.is_file():
+            candidates.append(archive)
+        candidates.extend(
+            path for path in sorted(realdata_path.rglob("*"))
+            if path.is_file() and "census1881" in str(path).lower()
+        )
+
+    if not candidates and env_truthy("REDIS_DOWNLOAD_CROARING_REALDATA"):
+        realdata_path.mkdir(parents=True, exist_ok=True)
+        archive = realdata_path / "census1881.zip"
+        if not archive.exists():
+            urlretrieve(f"{REALDATA_BASE_URL}/census1881.zip", archive)
+        candidates.append(archive)
+
+    merged_bits = set()
+    sources = []
+    for path in candidates:
+        if path.suffix.lower() == ".zip":
+            with ZipFile(path) as zf:
+                for member in sorted(name for name in zf.namelist() if not name.endswith("/")):
+                    with zf.open(member) as fp:
+                        text = fp.read().decode("utf-8", "replace")
+                    parsed = parse_realdata_text(text, max_values)
+                    if parsed:
+                        merged_bits.update(parsed)
+                        sources.append(f"{path.name}:{member}")
+                    if len(merged_bits) >= max_values:
+                        break
+        elif path.suffix.lower() in {"", ".txt", ".csv"}:
+            parsed = parse_realdata_text(path.read_text(encoding="utf-8", errors="replace"), max_values)
+            if parsed:
+                merged_bits.update(parsed)
+                sources.append(str(path))
+        if len(merged_bits) >= max_values:
+            break
+
+    if len(merged_bits) >= min_values:
+        return sorted(merged_bits)[:max_values], ",".join(sources[:4])
+
+    raise unittest.SkipTest(
+        "CRoaring census1881 realdata not found; set REDIS_CROARING_REALDATA_DIR "
+        "or REDIS_DOWNLOAD_CROARING_REALDATA=1"
+    )
+
+
+def real_redis_client(port, name):
+    return migrate.RedisClient(migrate.RedisEndpoint(
+        "127.0.0.1",
+        port,
+        0,
+        None,
+        None,
+        2.0,
+        name,
+    ))
+
+
+class RedisProcess:
+    def __init__(self, server_path, port, data_dir, module_path=None):
+        self.server_path = Path(server_path)
+        self.port = port
+        self.data_dir = Path(data_dir)
+        self.module_path = Path(module_path) if module_path is not None else None
+        self.proc = None
+
+    def __enter__(self):
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        args = [
+            str(self.server_path),
+            "--port", str(self.port),
+            "--bind", "127.0.0.1",
+            "--protected-mode", "no",
+            "--save", "",
+            "--appendonly", "no",
+            "--dir", str(self.data_dir),
+            "--dbfilename", "dump.rdb",
+            "--loglevel", "warning",
+        ]
+        if self.module_path is not None:
+            args.extend(["--loadmodule", str(self.module_path)])
+        self.proc = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.wait_ready()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.proc is None:
+            return
+        try:
+            if self.proc.poll() is None:
+                try:
+                    real_redis_client(self.port, "shutdown").execute(["SHUTDOWN", "NOSAVE"])
+                except Exception:
+                    pass
+                try:
+                    self.proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self.proc.terminate()
+                    try:
+                        self.proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        self.proc.kill()
+                        self.proc.wait(timeout=5)
+        finally:
+            if self.proc.stdout is not None:
+                self.proc.stdout.close()
+
+    def wait_ready(self):
+        client = real_redis_client(self.port, "redis-server")
+        deadline = time.time() + 10
+        last_error = None
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError(f"redis-server exited early:\n{self.output()}")
+            try:
+                if client.execute(["PING"]) == "PONG":
+                    return
+            except Exception as exc:
+                last_error = exc
+                time.sleep(0.05)
+        raise RuntimeError(f"redis-server did not start: {last_error}")
+
+    def output(self):
+        if self.proc is None or self.proc.stdout is None:
+            return ""
+        if self.proc.poll() is None:
+            return ""
+        return self.proc.stdout.read()
+
+
+class RealRedisRoaringMigrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source_server_path = redis_roaring_server_path()
+        cls.target_server_path = native_redis_server_path()
+        cls.module_path = redis_roaring_module_path()
+        missing = []
+        if cls.target_server_path is None:
+            missing.append("REDIS_NATIVE_SERVER is required for real native-bitmap target tests")
+        elif not cls.target_server_path.is_file():
+            missing.append(f"REDIS_NATIVE_SERVER not found: {cls.target_server_path}")
+        if not cls.source_server_path.is_file():
+            missing.append(f"REDIS_ROARING_SERVER not found: {cls.source_server_path}")
+        if not cls.module_path.is_file():
+            missing.append(f"REDIS_ROARING_MODULE not found: {cls.module_path}")
+        if missing:
+            raise unittest.SkipTest("; ".join(missing))
+
+    def run_migrator(self, args):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", ResourceWarning)
+                rc = migrate.main(args)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def start_pair(self, tmp):
+        source_port = free_tcp_port()
+        target_port = free_tcp_port()
+        source = RedisProcess(
+            self.source_server_path,
+            source_port,
+            Path(tmp) / "source",
+            self.module_path,
+        )
+        target = RedisProcess(self.target_server_path, target_port, Path(tmp) / "target")
+        return source, target, source_port, target_port
+
+    def migrator_args(self, source_port, target_port, manifest, key, *extra):
+        return [
+            "--source-host", "127.0.0.1",
+            "--source-port", str(source_port),
+            "--target-host", "127.0.0.1",
+            "--target-port", str(target_port),
+            "--manifest", str(manifest),
+            "--key", key,
+            "--apply",
+            "--assume-frozen",
+            "--page-size", "2",
+            "--socket-timeout", "2",
+            *extra,
+        ]
+
+    def migrator_scan_args(self, source_port, target_port, manifest, *extra):
+        return [
+            "--source-host", "127.0.0.1",
+            "--source-port", str(source_port),
+            "--target-host", "127.0.0.1",
+            "--target-port", str(target_port),
+            "--manifest", str(manifest),
+            "--apply",
+            "--assume-frozen",
+            "--socket-timeout", "2",
+            *extra,
+        ]
+
+    def assert_native_bits(self, client, key, set_bits, clear_bits, expected_count=None):
+        self.assertEqual(migrate.decode_text(client.execute(["TYPE", key])), "bitmap")
+        if expected_count is None:
+            expected_count = len(set_bits)
+        self.assertEqual(client.execute(["BITCOUNT", key]), expected_count)
+        for bit in set_bits:
+            self.assertEqual(client.execute(["GETBIT", key, str(bit)]), 1)
+        for bit in clear_bits:
+            self.assertEqual(client.execute(["GETBIT", key, str(bit)]), 0)
+
+    def assert_native_dataset(self, client, key, bits):
+        self.assertGreater(len(bits), 0)
+        probe_bits = bits[:4] + bits[len(bits) // 2:len(bits) // 2 + 4] + bits[-4:]
+        self.assert_native_bits(
+            client,
+            key,
+            probe_bits,
+            self.clear_bit_samples(bits),
+            expected_count=len(bits),
+        )
+        self.assertEqual(client.execute(["BITPOS", key, "1"]), bits[0])
+        self.assertEqual(client.execute(["GETBIT", key, str(bits[-1])]), 1)
+
+    def seed_roaring_int_array(self, client, command_prefix, key, bits, chunk_size=512):
+        client.execute(["DEL", key])
+        for index in range(0, len(bits), chunk_size):
+            chunk = bits[index:index + chunk_size]
+            command = f"{command_prefix}.SETINTARRAY" if index == 0 else f"{command_prefix}.APPENDINTARRAY"
+            client.execute([command, key, *chunk])
+
+    def seed_reroaring_int_array(self, client, key, bits, chunk_size=512):
+        self.seed_roaring_int_array(client, "R", key, bits, chunk_size)
+
+    def seed_roaring64_int_array(self, client, key, bits, chunk_size=512):
+        self.seed_roaring_int_array(client, "R64", key, bits, chunk_size)
+
+    def clear_bit_samples(self, bits, limit=8):
+        present = set(bits)
+        samples = []
+        candidate = 0
+        while len(samples) < limit:
+            if candidate not in present:
+                samples.append(candidate)
+            candidate += 1
+        return samples
+
+    def test_real_reroaring_migration_preserves_bits_and_ttl(self):
+        bits = {1, 2, 5, 100, 65536}
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                for bit in sorted(bits):
+                    source.execute(["R.SETBIT", "foo", str(bit), "1"])
+                source.execute(["PEXPIRE", "foo", "60000"])
+                source_ttl = source.execute(["PTTL", "foo"])
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(source_port, target_port, manifest, "foo")
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertIn("MIGRATED db=0 key=foo count=5", stdout)
+                self.assertEqual(stderr, "")
+                self.assert_native_bits(target, "foo", bits, {0, 3, 99, 65535})
+                target_ttl = target.execute(["PTTL", "foo"])
+                self.assertGreater(target_ttl, 0)
+                self.assertLessEqual(target_ttl, source_ttl + 1000)
+
+            data = json.loads(manifest.read_text())
+            entry = data["entries"][0]
+            self.assertEqual(entry["state"], "committed")
+            self.assertEqual(entry["source_type"], "reroaring")
+            self.assertEqual(entry["cardinality"], len(bits))
+            self.assertGreater(entry["validation"]["ttl_ms"], 0)
+
+    def test_real_roaring64_migration_preserves_in_cap_bits(self):
+        bits = {0, 63, 4096, 131072}
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                for bit in sorted(bits):
+                    source.execute(["R64.SETBIT", "wide", str(bit), "1"])
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(source_port, target_port, manifest, "wide")
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertIn("MIGRATED db=0 key=wide count=4", stdout)
+                self.assertEqual(stderr, "")
+                self.assert_native_bits(target, "wide", bits, {1, 64, 4097})
+
+            data = json.loads(manifest.read_text())
+            entry = data["entries"][0]
+            self.assertEqual(entry["state"], "committed")
+            self.assertEqual(entry["source_type"], "roaring64")
+            self.assertEqual(entry["cardinality"], len(bits))
+
+    def test_real_croaring_census1881_reroaring_migration_preserves_dataset(self):
+        bits, source_name = load_census1881_realdata_bits()
+        self.assertGreater(len(bits), 100)
+        self.assertLessEqual(max(bits), 0xFFFFFFFF)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                self.seed_reroaring_int_array(source, "census1881", bits)
+                self.assertEqual(source.execute(["R.BITCOUNT", "census1881"]), len(bits))
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(
+                        source_port,
+                        target_port,
+                        manifest,
+                        "census1881",
+                        "--page-size", "256",
+                        "--pipeline-size", "256",
+                    )
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertIn(f"MIGRATED db=0 key=census1881 count={len(bits)}", stdout)
+                self.assertEqual(stderr, "")
+                self.assert_native_dataset(target, "census1881", bits)
+
+            data = json.loads(manifest.read_text())
+            entry = data["entries"][0]
+            self.assertEqual(entry["state"], "committed")
+            self.assertEqual(entry["source_type"], "reroaring")
+            self.assertEqual(entry["cardinality"], len(bits))
+            self.assertEqual(entry["validation"]["cardinality"], len(bits))
+            self.assertIn("census1881", source_name)
+
+    def test_real_croaring_census1881_scan_migrates_multiple_prefixed_keys(self):
+        bits, source_name = load_census1881_realdata_bits(max_values=768, min_values=256)
+        datasets = {
+            "census1881:even": bits[::2],
+            "census1881:odd": bits[1::2],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                for key, key_bits in datasets.items():
+                    self.seed_reroaring_int_array(source, key, key_bits, chunk_size=128)
+                    self.assertEqual(source.execute(["R.BITCOUNT", key]), len(key_bits))
+                self.seed_reroaring_int_array(source, "outside-census1881", bits[:128], chunk_size=128)
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_scan_args(
+                        source_port,
+                        target_port,
+                        manifest,
+                        "--pattern", "census1881:*",
+                        "--target-prefix", "native:",
+                        "--page-size", "64",
+                        "--pipeline-size", "64",
+                    )
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(stderr, "")
+                for key, key_bits in datasets.items():
+                    self.assertIn(f"MIGRATED db=0 key={key} count={len(key_bits)}", stdout)
+                    self.assert_native_dataset(target, "native:" + key, key_bits)
+                self.assertEqual(target.execute(["EXISTS", "native:outside-census1881"]), 0)
+
+            data = json.loads(manifest.read_text())
+            entries = sorted(data["entries"], key=lambda entry: entry["key"])
+            self.assertEqual([entry["key"] for entry in entries], sorted(datasets))
+            for entry in entries:
+                key_bits = datasets[entry["key"]]
+                self.assertEqual(entry["state"], "committed")
+                self.assertEqual(entry["source_type"], "reroaring")
+                self.assertEqual(entry["destination_key"], "native:" + entry["key"])
+                self.assertEqual(entry["cardinality"], len(key_bits))
+                self.assertEqual(entry["validation"]["cardinality"], len(key_bits))
+                self.assertEqual(len(entry["full_diff_offsets"]), len(key_bits))
+            self.assertIn("census1881", source_name)
+
+    def test_real_croaring_census1881_roaring64_migration_preserves_dataset(self):
+        bits, source_name = load_census1881_realdata_bits(max_values=512, min_values=128)
+        self.assertGreater(len(bits), 100)
+        self.assertLessEqual(max(bits), 0xFFFFFFFF)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                self.seed_roaring64_int_array(source, "census1881-64", bits, chunk_size=128)
+                self.assertEqual(source.execute(["R64.BITCOUNT", "census1881-64"]), len(bits))
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(
+                        source_port,
+                        target_port,
+                        manifest,
+                        "census1881-64",
+                        "--page-size", "128",
+                        "--pipeline-size", "128",
+                    )
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertIn(f"MIGRATED db=0 key=census1881-64 count={len(bits)}", stdout)
+                self.assertEqual(stderr, "")
+                self.assert_native_dataset(target, "census1881-64", bits)
+
+            data = json.loads(manifest.read_text())
+            entry = data["entries"][0]
+            self.assertEqual(entry["state"], "committed")
+            self.assertEqual(entry["source_type"], "roaring64")
+            self.assertEqual(entry["cardinality"], len(bits))
+            self.assertEqual(entry["validation"]["cardinality"], len(bits))
+            self.assertIn("census1881", source_name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -164,7 +164,7 @@ class FakeRedisHandler(socketserver.BaseRequestHandler):
             values = sorted(self.server.bits[key])
             start = int(command[2])
             end = int(command[3])
-            reply = [value for value in values if start <= value <= end]
+            reply = values[start:end + 1]
             if self.server.mutate_after_range and key not in self.server.mutated_range_keys:
                 next_offset = max(values) + 1 if values else 0
                 self.server.bits[key].add(next_offset)
@@ -428,11 +428,11 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             self.assertEqual(data["entries"][0]["cardinality"], 4)
             self.assertEqual(data["entries"][0]["validation"]["type"], "bitmap")
 
-    def test_apply_migrates_sparse_reroaring_key_by_offset_range(self):
+    def test_apply_migrates_sparse_reroaring_key_by_rank_range(self):
         with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={100, 200}) as servers:
             manifest = Path(tmp) / "manifest.json"
             rc, stdout, stderr = self.run_migrator(
-                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "100")
+                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "1")
             )
 
             self.assertEqual(rc, 0)
@@ -444,8 +444,8 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 command for command in servers.source.commands
                 if command and command[0].upper() == b"R.RANGEINTARRAY"
             ]
-            self.assertEqual(range_commands[0][2:], [b"100", b"199"])
-            self.assertEqual(range_commands[1][2:], [b"200", b"200"])
+            self.assertEqual(range_commands[0][2:], [b"0", b"0"])
+            self.assertEqual(range_commands[1][2:], [b"1", b"1"])
 
     def test_apply_preserves_empty_source_as_empty_native_bitmap(self):
         with tempfile.TemporaryDirectory() as tmp, ServerPair(bits=set()) as servers:

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -164,7 +164,7 @@ class FakeRedisHandler(socketserver.BaseRequestHandler):
             values = sorted(self.server.bits[key])
             start = int(command[2])
             end = int(command[3])
-            reply = values[start:end + 1]
+            reply = [value for value in values if start <= value <= end]
             if self.server.mutate_after_range and key not in self.server.mutated_range_keys:
                 next_offset = max(values) + 1 if values else 0
                 self.server.bits[key].add(next_offset)
@@ -358,6 +358,58 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 rc = migrate.main(args)
         return rc, stdout.getvalue(), stderr.getvalue()
 
+    def test_scanned_same_endpoint_apply_snapshots_keys_before_migrating(self):
+        class DummyClient:
+            def __init__(self, endpoint):
+                self.endpoint = endpoint
+
+            def with_db(self, db):
+                return DummyClient(self.endpoint.with_db(db))
+
+        class SnapshotMigrator(migrate.BitmapMigrator):
+            def __init__(self):
+                self.args = migrate.parse_args([
+                    "--source-host", "127.0.0.1",
+                    "--source-port", "6379",
+                    "--target-host", "127.0.0.1",
+                    "--target-port", "6379",
+                    "--manifest", "unused.json",
+                    "--apply",
+                    "--assume-frozen",
+                ])
+                endpoint = migrate.RedisEndpoint("127.0.0.1", 6379, 0, None, None, 1.0, "dummy")
+                self.source = DummyClient(endpoint)
+                self.target = DummyClient(endpoint)
+                self.summary = {
+                    "scanned": 0,
+                    "non_roaring": 0,
+                    "planned": 0,
+                    "migrated": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                    "resumed": 0,
+                }
+                self.events = []
+
+            def iter_keys(self, source):
+                for key in (b"foo", b"bar"):
+                    self.events.append(("yield", key))
+                    yield key
+
+            def migrate_key(self, source, target, db, key):
+                self.events.append(("migrate", key))
+
+        migrator = SnapshotMigrator()
+        migrator.migrate_db(0)
+
+        self.assertEqual(migrator.summary["scanned"], 2)
+        self.assertEqual(migrator.events, [
+            ("yield", b"foo"),
+            ("yield", b"bar"),
+            ("migrate", b"foo"),
+            ("migrate", b"bar"),
+        ])
+
     def test_apply_migrates_reroaring_key(self):
         with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={1, 2, 5, 100}) as servers:
             manifest = Path(tmp) / "manifest.json"
@@ -375,6 +427,25 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             self.assertEqual(data["entries"][0]["state"], "committed")
             self.assertEqual(data["entries"][0]["cardinality"], 4)
             self.assertEqual(data["entries"][0]["validation"]["type"], "bitmap")
+
+    def test_apply_migrates_sparse_reroaring_key_by_offset_range(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={100, 200}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "100")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {100, 200})
+
+            range_commands = [
+                command for command in servers.source.commands
+                if command and command[0].upper() == b"R.RANGEINTARRAY"
+            ]
+            self.assertEqual(range_commands[0][2:], [b"100", b"199"])
+            self.assertEqual(range_commands[1][2:], [b"200", b"200"])
 
     def test_apply_preserves_empty_source_as_empty_native_bitmap(self):
         with tempfile.TemporaryDirectory() as tmp, ServerPair(bits=set()) as servers:
@@ -497,6 +568,20 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             self.assertEqual(data["entries"][0]["state"], "failed")
             self.assertIn(str(wide), data["entries"][0]["error"])
 
+    def test_roaring64_above_cap_keep_going_counts_failure(self):
+        wide = migrate.NATIVE_V1_MAX_BIT + 1
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(source_type="roaring64", bits={wide}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--source-type", "auto", "--keep-going")
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertIn("failed=1", stdout)
+            self.assertIn("FAILED db=0 key=foo", stderr)
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "failed")
+
     def test_roaring64_above_cap_can_skip_loudly(self):
         wide = migrate.NATIVE_V1_MAX_BIT + 1
         with tempfile.TemporaryDirectory() as tmp, ServerPair(source_type="roaring64", bits={wide}) as servers:
@@ -601,6 +686,31 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             self.assertNotIn(temp_key, servers.target.target)
             data = json.loads(manifest.read_text())
             self.assertEqual(data["entries"][0]["state"], "committed")
+
+    def test_resume_frozen_pass_refreshes_committed_live_copy(self):
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={100, 200}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--apply", "--allow-live-copy", "--page-size", "100")
+            )
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {100, 200})
+
+            servers.source.bits[b"foo"].add(300)
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--resume", "--apply", "--assume-frozen", "--page-size", "100")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertIn("MIGRATED db=0 key=foo count=3", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(servers.target.target[b"foo"], {100, 200, 300})
+            data = json.loads(manifest.read_text())
+            self.assertEqual(data["entries"][0]["state"], "committed")
+            self.assertTrue(data["entries"][0]["source_writes_frozen"])
 
 
 def free_tcp_port():

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -1038,6 +1038,65 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
             self.assertEqual(entry["cardinality"], len(bits))
             self.assertGreater(entry["validation"]["ttl_ms"], 0)
 
+    def test_real_reroaring_rdb_snapshot_migrates_to_native_rdb(self):
+        key = "snapshot:reroaring"
+        bits = sorted({0, 7, 63, 64, 511, 4096, 65535})
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            manifest = tmp_path / "manifest.json"
+            source_data = tmp_path / "source"
+            target_data = tmp_path / "target"
+
+            seed_port = free_tcp_port()
+            with RedisProcess(self.source_server_path, seed_port, source_data, self.module_path):
+                source = real_redis_client(seed_port, "source-seed")
+                self.seed_reroaring_int_array(source, key, bits, chunk_size=3)
+                self.assertEqual(source.execute(["R.BITCOUNT", key]), len(bits))
+                self.assertIsInstance(source.execute(["DUMP", key]), bytes)
+                self.assertEqual(source.execute(["SAVE"]), "OK")
+                self.assertTrue((source_data / "dump.rdb").is_file())
+
+            source_port = free_tcp_port()
+            target_port = free_tcp_port()
+            source_proc = RedisProcess(self.source_server_path, source_port, source_data, self.module_path)
+            target_proc = RedisProcess(self.target_server_path, target_port, target_data)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source-rdb")
+                target = real_redis_client(target_port, "target")
+                self.assertEqual(source.execute(["R.BITCOUNT", key]), len(bits))
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(
+                        source_port,
+                        target_port,
+                        manifest,
+                        key,
+                        "--page-size", "64",
+                        "--pipeline-size", "4",
+                    )
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertIn(f"MIGRATED db=0 key={key} count={len(bits)}", stdout)
+                self.assertEqual(stderr, "")
+                self.assert_native_dataset(target, key, bits)
+                self.assertEqual(target.execute(["SAVE"]), "OK")
+                self.assertTrue((target_data / "dump.rdb").is_file())
+
+            reload_port = free_tcp_port()
+            with RedisProcess(self.target_server_path, reload_port, target_data):
+                reloaded = real_redis_client(reload_port, "target-reload")
+                self.assert_native_dataset(reloaded, key, bits)
+
+            data = json.loads(manifest.read_text())
+            entry = data["entries"][0]
+            self.assertEqual(entry["state"], "committed")
+            self.assertEqual(entry["source_type"], "reroaring")
+            self.assertEqual(entry["cardinality"], len(bits))
+            self.assertTrue(entry["source_hash"].startswith("sha256:"))
+            self.assertEqual(entry["validation"]["type"], "bitmap")
+            self.assertEqual(entry["validation"]["cardinality"], len(bits))
+
     def test_real_roaring64_migration_preserves_in_cap_bits(self):
         bits = {0, 63, 4096, 131072}
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -684,22 +684,23 @@ class BitmapMigrator:
             dst.command(["BITMAP", "CONVERT", build_key, "NATIVE"])
 
             if info.cardinality:
-                range_start = info.min_offset
-                while range_start <= info.max_offset:
-                    range_end = min(info.max_offset, range_start + self.args.page_size - 1)
+                # redis-roaring RANGEINTARRAY arguments are element ranks, not bit offsets.
+                rank_start = 0
+                while rank_start < info.cardinality:
+                    rank_end = min(info.cardinality - 1, rank_start + self.args.page_size - 1)
                     raw_offsets = src.command([
                         f"{info.command_prefix}.RANGEINTARRAY",
                         info.key,
-                        str(range_start),
-                        str(range_end),
+                        str(rank_start),
+                        str(rank_end),
                     ])
                     if not isinstance(raw_offsets, list):
                         raise MigrateError(f"unexpected RANGEINTARRAY reply for {key_to_text(info.key)}")
                     offsets = [parse_uint(offset, "offset") for offset in raw_offsets]
+                    if len(offsets) > self.args.page_size:
+                        raise MigrateError(f"source returned too many offsets for {key_to_text(info.key)}")
                     commands: list[list[Any]] = []
                     for i, offset in enumerate(offsets):
-                        if offset < range_start or offset > range_end:
-                            raise MigrateError(f"source returned offset {offset} outside requested range")
                         if offset > NATIVE_V1_MAX_BIT:
                             raise MigrateError(f"offset {offset} exceeds v1 native bitmap cap")
                         if last_offset is not None and offset <= last_offset:
@@ -713,7 +714,7 @@ class BitmapMigrator:
                         last_offset = offset
                     self.send_in_chunks(dst, commands, self.args.pipeline_size)
                     exported_count += len(offsets)
-                    range_start = range_end + 1
+                    rank_start = rank_end + 1
 
             if exported_count != info.cardinality:
                 raise MigrateError(

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -363,6 +363,7 @@ class BitmapMigrator:
             "failed": 0,
             "resumed": 0,
         }
+        self.failed_entries_this_run: set[str] = set()
 
     def run(self) -> int:
         self.manifest.save()
@@ -411,7 +412,11 @@ class BitmapMigrator:
     def migrate_db(self, db: int) -> None:
         source = self.source.with_db(db)
         target = self.target.with_db(db)
-        for key in self.iter_keys(source):
+        keys = self.iter_keys(source)
+        if self.should_snapshot_scan():
+            # Finish SCAN before apply-mode writes mutate the keyspace.
+            keys = list(keys)
+        for key in keys:
             self.summary["scanned"] += 1
             try:
                 self.migrate_key(source, target, db, key)
@@ -456,10 +461,14 @@ class BitmapMigrator:
                 if cursor == 0:
                     break
 
+    def should_snapshot_scan(self) -> bool:
+        return self.args.apply and not self.args.key and not self.args.key_file
+
     def migrate_key(self, source: RedisClient, target: RedisClient, db: int, key: bytes) -> None:
         entry_id = self.entry_id(db, key)
         existing = self.manifest.get(entry_id)
-        if existing and existing.get("state") in {"committed", "skipped"}:
+        refresh_committed = self.should_refresh_committed_entry(existing)
+        if existing and existing.get("state") in {"committed", "skipped"} and not refresh_committed:
             self.summary["resumed"] += 1
             return
         if existing and existing.get("state") == "dry_run" and self.args.dry_run:
@@ -490,7 +499,7 @@ class BitmapMigrator:
                 self.manifest.upsert(entry)
                 print(f"SKIP db={db} key={key_to_text(key)}: {error}", file=sys.stderr)
                 return
-            entry["state"] = "failed"
+            entry["state"] = "planned"
             self.manifest.upsert(entry)
             raise MigrateError(error)
 
@@ -518,13 +527,26 @@ class BitmapMigrator:
         entry["state"] = "validated"
         self.manifest.upsert(entry)
 
-        self.commit_temp(target, dest_key, temp_key)
+        self.commit_temp(target, dest_key, temp_key, replace=refresh_committed)
         entry["state"] = "committed"
         entry["committed_at_ms"] = now_ms()
+        entry["source_writes_frozen"] = bool(self.args.assume_frozen)
         entry["error"] = None
         self.manifest.upsert(entry)
         self.summary["migrated"] += 1
         print(f"MIGRATED db={db} key={key_to_text(key)} count={info.cardinality}")
+
+    def should_refresh_committed_entry(self, entry: Optional[dict[str, Any]]) -> bool:
+        if not entry or entry.get("state") != "committed":
+            return False
+        if not (self.args.resume and self.args.apply and self.args.assume_frozen):
+            return False
+        if entry.get("source_writes_frozen") is False:
+            return True
+        if "source_writes_frozen" not in entry:
+            options = self.manifest.data.get("options") or {}
+            return bool(options.get("allow_live_copy") and not options.get("assume_frozen"))
+        return False
 
     def resume_imported_key(
         self,
@@ -551,6 +573,7 @@ class BitmapMigrator:
             self.commit_temp(target, dest_key, temp_key)
             entry["state"] = "committed"
             entry["committed_at_ms"] = now_ms()
+            entry["source_writes_frozen"] = bool(self.args.assume_frozen)
             entry["error"] = None
             self.manifest.upsert(entry)
             self.summary["migrated"] += 1
@@ -562,6 +585,7 @@ class BitmapMigrator:
             entry["validation"] = validation
             entry["state"] = "committed"
             entry["committed_at_ms"] = now_ms()
+            entry["source_writes_frozen"] = bool(self.args.assume_frozen)
             entry["error"] = None
             self.manifest.upsert(entry)
             self.summary["resumed"] += 1
@@ -660,30 +684,27 @@ class BitmapMigrator:
             dst.command(["BITMAP", "CONVERT", build_key, "NATIVE"])
 
             if info.cardinality:
-                for rank_start in range(0, info.cardinality, self.args.page_size):
-                    rank_end = min(info.cardinality - 1, rank_start + self.args.page_size - 1)
+                range_start = info.min_offset
+                while range_start <= info.max_offset:
+                    range_end = min(info.max_offset, range_start + self.args.page_size - 1)
                     raw_offsets = src.command([
                         f"{info.command_prefix}.RANGEINTARRAY",
                         info.key,
-                        str(rank_start),
-                        str(rank_end),
+                        str(range_start),
+                        str(range_end),
                     ])
                     if not isinstance(raw_offsets, list):
                         raise MigrateError(f"unexpected RANGEINTARRAY reply for {key_to_text(info.key)}")
-                    expected = rank_end - rank_start + 1
-                    if len(raw_offsets) != expected:
-                        raise MigrateError(
-                            f"source changed while exporting {key_to_text(info.key)}: "
-                            f"expected {expected} offsets, got {len(raw_offsets)}"
-                        )
                     offsets = [parse_uint(offset, "offset") for offset in raw_offsets]
                     commands: list[list[Any]] = []
                     for i, offset in enumerate(offsets):
+                        if offset < range_start or offset > range_end:
+                            raise MigrateError(f"source returned offset {offset} outside requested range")
                         if offset > NATIVE_V1_MAX_BIT:
                             raise MigrateError(f"offset {offset} exceeds v1 native bitmap cap")
                         if last_offset is not None and offset <= last_offset:
                             raise MigrateError(f"source offsets are not strictly increasing at {offset}")
-                        absolute_rank = rank_start + i
+                        absolute_rank = exported_count + i
                         if absolute_rank in sample_ranks:
                             sample_offsets.add(offset)
                         if full_offsets is not None:
@@ -692,6 +713,7 @@ class BitmapMigrator:
                         last_offset = offset
                     self.send_in_chunks(dst, commands, self.args.pipeline_size)
                     exported_count += len(offsets)
+                    range_start = range_end + 1
 
             if exported_count != info.cardinality:
                 raise MigrateError(
@@ -790,15 +812,16 @@ class BitmapMigrator:
                 raise MigrateError("temporary key lost source TTL")
         return checks
 
-    def commit_temp(self, target: RedisClient, dest_key: bytes, temp_key: bytes) -> None:
+    def commit_temp(self, target: RedisClient, dest_key: bytes, temp_key: bytes, replace: bool = False) -> None:
         with target.connection() as conn:
             exists = parse_uint(conn.command(["EXISTS", dest_key]), "EXISTS destination")
-            if exists and not self.args.replace:
+            use_replace = self.args.replace or replace
+            if exists and not use_replace:
                 conn.command(["DEL", temp_key])
                 raise MigrateError(f"destination key already exists: {key_to_text(dest_key)} (use --replace)")
             if parse_uint(conn.command(["EXISTS", temp_key]), "EXISTS temp") != 1:
                 raise MigrateError(f"temporary key is missing before commit: {key_to_text(temp_key)}")
-            if self.args.replace:
+            if use_replace:
                 conn.command(["RENAME", temp_key, dest_key])
                 return
             renamed = parse_uint(conn.command(["RENAMENX", temp_key, dest_key]), "RENAMENX")
@@ -814,11 +837,11 @@ class BitmapMigrator:
             "key": key_to_text(key),
             "key_b64": key_to_b64(key),
         }
-        already_failed = entry.get("state") == "failed"
         entry["state"] = "failed"
         entry["error"] = error
-        if not already_failed:
+        if entry_id not in self.failed_entries_this_run:
             self.summary["failed"] += 1
+            self.failed_entries_this_run.add(entry_id)
         self.manifest.upsert(entry)
         print(f"FAILED db={db} key={key_to_text(key)}: {error}", file=sys.stderr)
 
@@ -844,6 +867,7 @@ class BitmapMigrator:
             "max_observed_offset": info.max_offset,
             "source_hash": info.source_hash,
             "overwrite_policy": "replace" if self.args.replace else "no-overwrite",
+            "source_writes_frozen": bool(self.args.assume_frozen),
             "cap_policy": self.args.cap_policy,
             "error": None,
         }

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -1,0 +1,951 @@
+#!/usr/bin/env python3
+"""Streaming redis-roaring to native Redis bitmap migrator.
+
+The tool intentionally lives outside Redis core. It reads redis-roaring module
+keys through bounded integer-array commands, builds target-native bitmap values
+with the target Redis encoder, validates temporary keys, and then atomically
+renames them into place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import socket
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+
+NATIVE_V1_MAX_BIT = 4294967295
+MANIFEST_VERSION = 1
+
+
+class MigrateError(RuntimeError):
+    pass
+
+
+class RedisError(MigrateError):
+    pass
+
+
+def encode_resp(parts: list[Any]) -> bytes:
+    out = [f"*{len(parts)}\r\n".encode()]
+    for part in parts:
+        if isinstance(part, bytes):
+            data = part
+        else:
+            data = str(part).encode("utf-8")
+        out.append(f"${len(data)}\r\n".encode())
+        out.append(data)
+        out.append(b"\r\n")
+    return b"".join(out)
+
+
+def decode_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+def parse_uint(value: Any, field: str) -> int:
+    if isinstance(value, int):
+        if value < 0:
+            raise MigrateError(f"{field} is negative: {value}")
+        return value
+    text = decode_text(value).strip()
+    if not text.isdigit():
+        raise MigrateError(f"{field} is not an unsigned integer: {text!r}")
+    return int(text)
+
+
+def parse_offset_or_minus_one(value: Any, field: str) -> int:
+    if isinstance(value, int):
+        if value < -1:
+            raise MigrateError(f"{field} is less than -1: {value}")
+        return value
+    text = decode_text(value).strip()
+    if text == "-1":
+        return -1
+    if not text.isdigit():
+        raise MigrateError(f"{field} is not an offset or -1: {text!r}")
+    return int(text)
+
+
+def is_wrongtype_error(exc: RedisError) -> bool:
+    message = str(exc).upper()
+    return "WRONGTYPE" in message or "OPERATION AGAINST A KEY" in message
+
+
+def is_unknown_command_error(exc: RedisError) -> bool:
+    message = str(exc).upper()
+    return "UNKNOWN COMMAND" in message or "ERR UNKNOWN" in message
+
+
+def key_to_text(key: bytes) -> str:
+    return key.decode("utf-8", "replace")
+
+
+def key_to_b64(key: bytes) -> str:
+    return base64.b64encode(key).decode("ascii")
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclass(frozen=True)
+class RedisEndpoint:
+    host: str
+    port: int
+    db: int
+    user: Optional[str]
+    password: Optional[str]
+    timeout: float
+    name: str
+
+    def with_db(self, db: int) -> "RedisEndpoint":
+        return RedisEndpoint(
+            host=self.host,
+            port=self.port,
+            db=db,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+            name=self.name,
+        )
+
+
+class RespConnection:
+    def __init__(self, endpoint: RedisEndpoint):
+        self.endpoint = endpoint
+        self.sock: Optional[socket.socket] = None
+        self.fp: Any = None
+
+    def __enter__(self) -> "RespConnection":
+        self.sock = socket.create_connection((self.endpoint.host, self.endpoint.port), timeout=self.endpoint.timeout)
+        self.sock.settimeout(self.endpoint.timeout)
+        self.fp = self.sock.makefile("rb")
+        if self.endpoint.password:
+            if self.endpoint.user:
+                self.command(["AUTH", self.endpoint.user, self.endpoint.password])
+            else:
+                self.command(["AUTH", self.endpoint.password])
+        if self.endpoint.db:
+            self.command(["SELECT", str(self.endpoint.db)])
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if self.fp is not None:
+            self.fp.close()
+        if self.sock is not None:
+            self.sock.close()
+
+    def command(self, parts: list[Any]) -> Any:
+        if self.sock is None:
+            raise MigrateError("RESP connection is not open")
+        self.sock.sendall(encode_resp(parts))
+        return self.read_response()
+
+    def send_pipeline(self, commands: list[list[Any]]) -> list[Any]:
+        if not commands:
+            return []
+        if self.sock is None:
+            raise MigrateError("RESP connection is not open")
+        self.sock.sendall(b"".join(encode_resp(cmd) for cmd in commands))
+        return [self.read_response() for _ in commands]
+
+    def read_response(self) -> Any:
+        if self.fp is None:
+            raise MigrateError("RESP connection is not open")
+        prefix = self.fp.read(1)
+        if not prefix:
+            raise RedisError(f"{self.endpoint.name}: redis closed the connection")
+        if prefix == b"+":
+            return self._read_line().decode("utf-8", "replace")
+        if prefix == b"-":
+            raise RedisError(self._read_line().decode("utf-8", "replace"))
+        if prefix == b":":
+            return int(self._read_line())
+        if prefix == b",":
+            return float(self._read_line())
+        if prefix == b"#":
+            raw = self._read_line()
+            return raw == b"t"
+        if prefix == b"_":
+            self._read_line()
+            return None
+        if prefix == b"$":
+            return self._read_bulk()
+        if prefix == b"=":
+            return self._read_bulk()
+        if prefix == b"*":
+            return self._read_array()
+        if prefix == b"%":
+            length = int(self._read_line())
+            out: dict[Any, Any] = {}
+            for _ in range(length):
+                key = self.read_response()
+                out[key] = self.read_response()
+            return out
+        raise RedisError(f"{self.endpoint.name}: unknown RESP prefix: {prefix!r}")
+
+    def _read_line(self) -> bytes:
+        if self.fp is None:
+            raise MigrateError("RESP connection is not open")
+        line = self.fp.readline()
+        if not line.endswith(b"\r\n"):
+            raise RedisError(f"{self.endpoint.name}: invalid RESP line")
+        return line[:-2]
+
+    def _read_bulk(self) -> Optional[bytes]:
+        length = int(self._read_line())
+        if length == -1:
+            return None
+        data = self.fp.read(length)
+        crlf = self.fp.read(2)
+        if crlf != b"\r\n":
+            raise RedisError(f"{self.endpoint.name}: invalid bulk string terminator")
+        return data
+
+    def _read_array(self) -> Optional[list[Any]]:
+        length = int(self._read_line())
+        if length == -1:
+            return None
+        return [self.read_response() for _ in range(length)]
+
+
+class RedisClient:
+    def __init__(self, endpoint: RedisEndpoint):
+        self.endpoint = endpoint
+
+    def with_db(self, db: int) -> "RedisClient":
+        return RedisClient(self.endpoint.with_db(db))
+
+    def connection(self) -> RespConnection:
+        return RespConnection(self.endpoint)
+
+    def execute(self, command: list[Any]) -> Any:
+        with self.connection() as conn:
+            return conn.command(command)
+
+
+@dataclass
+class SourceInfo:
+    db: int
+    key: bytes
+    source_type: str
+    command_prefix: str
+    cardinality: int
+    min_offset: int
+    max_offset: int
+    expire_at_ms: Optional[int]
+    ttl_ms: int
+    source_hash: Optional[str]
+
+
+class Manifest:
+    def __init__(self, path: Path, args: argparse.Namespace):
+        self.path = path
+        self.data: dict[str, Any] = {
+            "version": MANIFEST_VERSION,
+            "created_at_ms": now_ms(),
+            "updated_at_ms": now_ms(),
+            "tool": "redis-bitmap-migrate",
+            "options": self._safe_options(args),
+            "entries": [],
+        }
+        self.entries_by_id: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _safe_options(args: argparse.Namespace) -> dict[str, Any]:
+        hidden = {"source_password", "target_password"}
+        result: dict[str, Any] = {}
+        for key, value in vars(args).items():
+            if key in hidden and value:
+                result[key] = "<redacted>"
+            elif isinstance(value, Path):
+                result[key] = str(value)
+            else:
+                result[key] = value
+        return result
+
+    @classmethod
+    def load_or_create(cls, path: Path, args: argparse.Namespace, resume: bool) -> "Manifest":
+        manifest = cls(path, args)
+        if path.exists():
+            if not resume:
+                raise MigrateError(f"manifest already exists: {path} (use --resume or choose another path)")
+            with path.open("r", encoding="utf-8") as fp:
+                manifest.data = json.load(fp)
+            if manifest.data.get("version") != MANIFEST_VERSION:
+                raise MigrateError(f"unsupported manifest version in {path}")
+        for entry in manifest.data.get("entries", []):
+            entry_id = entry.get("id")
+            if entry_id:
+                manifest.entries_by_id[entry_id] = entry
+        return manifest
+
+    def get(self, entry_id: str) -> Optional[dict[str, Any]]:
+        return self.entries_by_id.get(entry_id)
+
+    def upsert(self, entry: dict[str, Any]) -> None:
+        entry["updated_at_ms"] = now_ms()
+        entry_id = entry["id"]
+        existing = self.entries_by_id.get(entry_id)
+        if existing is None:
+            self.data.setdefault("entries", []).append(entry)
+            self.entries_by_id[entry_id] = entry
+        elif existing is entry:
+            pass
+        else:
+            existing.clear()
+            existing.update(entry)
+        self.data["updated_at_ms"] = now_ms()
+        self.save()
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fp:
+                json.dump(self.data, fp, indent=2, sort_keys=True)
+                fp.write("\n")
+            os.replace(tmp, self.path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+class BitmapMigrator:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.source = RedisClient(
+            RedisEndpoint(
+                args.source_host,
+                args.source_port,
+                0,
+                args.source_user,
+                args.source_password,
+                args.socket_timeout,
+                "source",
+            )
+        )
+        self.target = RedisClient(
+            RedisEndpoint(
+                args.target_host,
+                args.target_port,
+                0,
+                args.target_user,
+                args.target_password,
+                args.socket_timeout,
+                "target",
+            )
+        )
+        self.manifest = Manifest.load_or_create(Path(args.manifest), args, args.resume)
+        self.summary = {
+            "scanned": 0,
+            "non_roaring": 0,
+            "planned": 0,
+            "migrated": 0,
+            "skipped": 0,
+            "failed": 0,
+            "resumed": 0,
+        }
+
+    def run(self) -> int:
+        self.manifest.save()
+        self.preflight()
+        dbs = self.discover_dbs()
+        for db in dbs:
+            self.migrate_db(db)
+        self.print_summary()
+        return 1 if self.summary["failed"] else 0
+
+    def preflight(self) -> None:
+        self.source.execute(["PING"])
+        self.target.execute(["PING"])
+        if self.args.apply and not self.args.assume_frozen and not self.args.allow_live_copy:
+            raise MigrateError("--apply requires --assume-frozen or --allow-live-copy")
+        if self.cluster_enabled(self.source) and not self.args.allow_cluster:
+            raise MigrateError("source cluster mode is enabled; this tool does not migrate cluster targets unless --allow-cluster is set")
+        if self.cluster_enabled(self.target) and not self.args.allow_cluster:
+            raise MigrateError("target cluster mode is enabled; this tool does not migrate cluster targets unless --allow-cluster is set")
+        if self.args.allow_cluster:
+            raise MigrateError("cluster migration is not implemented yet; rerun against standalone masters or omit --allow-cluster")
+
+    def cluster_enabled(self, client: RedisClient) -> bool:
+        try:
+            raw = decode_text(client.execute(["INFO", "cluster"]))
+        except RedisError:
+            return False
+        for line in raw.splitlines():
+            if line.startswith("cluster_enabled:"):
+                return line.split(":", 1)[1].strip() == "1"
+        return False
+
+    def discover_dbs(self) -> list[int]:
+        if self.args.all_dbs:
+            raw = decode_text(self.source.execute(["INFO", "keyspace"]))
+            dbs: list[int] = []
+            for line in raw.splitlines():
+                if not line.startswith("db") or ":" not in line:
+                    continue
+                name = line.split(":", 1)[0]
+                if name[2:].isdigit():
+                    dbs.append(int(name[2:]))
+            return sorted(dbs) or [0]
+        return sorted(set(self.args.db))
+
+    def migrate_db(self, db: int) -> None:
+        source = self.source.with_db(db)
+        target = self.target.with_db(db)
+        for key in self.iter_keys(source):
+            self.summary["scanned"] += 1
+            try:
+                self.migrate_key(source, target, db, key)
+            except RedisError as exc:
+                self.record_failure(db, key, str(exc))
+                if not self.args.keep_going:
+                    raise
+            except MigrateError as exc:
+                self.record_failure(db, key, str(exc))
+                if not self.args.keep_going:
+                    raise
+
+    def iter_keys(self, source: RedisClient) -> Iterator[bytes]:
+        if self.args.key:
+            for key in self.args.key:
+                yield key.encode("utf-8")
+            return
+        if self.args.key_file:
+            with open(self.args.key_file, "rb") as fp:
+                for raw in fp:
+                    key = raw.rstrip(b"\r\n")
+                    if key:
+                        yield key
+            return
+
+        cursor = 0
+        with source.connection() as conn:
+            while True:
+                command: list[Any] = ["SCAN", str(cursor), "COUNT", str(self.args.scan_count)]
+                if self.args.pattern:
+                    command.extend(["MATCH", self.args.pattern])
+                reply = conn.command(command)
+                if not isinstance(reply, list) or len(reply) != 2:
+                    raise MigrateError(f"unexpected SCAN reply: {reply!r}")
+                cursor = parse_uint(reply[0], "SCAN cursor")
+                keys = reply[1] or []
+                for key in keys:
+                    if isinstance(key, bytes):
+                        yield key
+                    else:
+                        yield str(key).encode("utf-8")
+                if cursor == 0:
+                    break
+
+    def migrate_key(self, source: RedisClient, target: RedisClient, db: int, key: bytes) -> None:
+        entry_id = self.entry_id(db, key)
+        existing = self.manifest.get(entry_id)
+        if existing and existing.get("state") in {"committed", "skipped"}:
+            self.summary["resumed"] += 1
+            return
+        if existing and existing.get("state") == "dry_run" and self.args.dry_run:
+            self.summary["resumed"] += 1
+            return
+
+        info = self.detect_source(source, db, key)
+        if info is None:
+            if self.args.key or self.args.key_file or self.args.strict_scan:
+                raise MigrateError("key is not a redis-roaring bitmap")
+            self.summary["non_roaring"] += 1
+            return
+
+        dest_key = self.destination_key(key)
+        build_key = self.manifest_key(db, key, b"build")
+        temp_key = self.manifest_key(db, key, b"tmp")
+        entry = self.base_entry(info, dest_key, build_key, temp_key)
+
+        if info.max_offset > NATIVE_V1_MAX_BIT:
+            error = (
+                f"source max offset {info.max_offset} exceeds v1 native bitmap cap "
+                f"{NATIVE_V1_MAX_BIT}"
+            )
+            entry["error"] = error
+            if self.args.cap_policy == "skip":
+                entry["state"] = "skipped"
+                self.summary["skipped"] += 1
+                self.manifest.upsert(entry)
+                print(f"SKIP db={db} key={key_to_text(key)}: {error}", file=sys.stderr)
+                return
+            entry["state"] = "failed"
+            self.manifest.upsert(entry)
+            raise MigrateError(error)
+
+        if self.args.dry_run:
+            entry["state"] = "dry_run"
+            self.summary["planned"] += 1
+            self.manifest.upsert(entry)
+            print(f"DRY-RUN db={db} key={key_to_text(key)} type={info.source_type} count={info.cardinality}")
+            return
+
+        if existing and self.args.resume:
+            if self.resume_imported_key(target, info, existing, dest_key, temp_key):
+                return
+
+        entry["state"] = "exporting"
+        self.manifest.upsert(entry)
+        samples, full_offsets = self.import_to_temp(source, target, info, build_key, temp_key)
+        entry["sample_offsets"] = sorted(samples)
+        entry["full_diff_offsets"] = sorted(full_offsets) if full_offsets is not None else None
+        entry["state"] = "imported"
+        self.manifest.upsert(entry)
+
+        validation = self.validate_temp(target, info, temp_key, samples, full_offsets)
+        entry["validation"] = validation
+        entry["state"] = "validated"
+        self.manifest.upsert(entry)
+
+        self.commit_temp(target, dest_key, temp_key)
+        entry["state"] = "committed"
+        entry["committed_at_ms"] = now_ms()
+        entry["error"] = None
+        self.manifest.upsert(entry)
+        self.summary["migrated"] += 1
+        print(f"MIGRATED db={db} key={key_to_text(key)} count={info.cardinality}")
+
+    def resume_imported_key(
+        self,
+        target: RedisClient,
+        info: SourceInfo,
+        entry: dict[str, Any],
+        dest_key: bytes,
+        temp_key: bytes,
+    ) -> bool:
+        state = entry.get("state")
+        if state not in {"imported", "validated", "committing"}:
+            return False
+        sample_offsets = {int(offset) for offset in entry.get("sample_offsets") or []}
+        full_raw = entry.get("full_diff_offsets")
+        full_offsets = None if full_raw is None else {int(offset) for offset in full_raw}
+
+        if parse_uint(target.execute(["EXISTS", temp_key]), "EXISTS temp") == 1:
+            validation = self.validate_temp(target, info, temp_key, sample_offsets, full_offsets)
+            entry["validation"] = validation
+            entry["state"] = "validated"
+            self.manifest.upsert(entry)
+            entry["state"] = "committing"
+            self.manifest.upsert(entry)
+            self.commit_temp(target, dest_key, temp_key)
+            entry["state"] = "committed"
+            entry["committed_at_ms"] = now_ms()
+            entry["error"] = None
+            self.manifest.upsert(entry)
+            self.summary["migrated"] += 1
+            print(f"RESUMED db={info.db} key={key_to_text(info.key)} from temporary key")
+            return True
+
+        if parse_uint(target.execute(["EXISTS", dest_key]), "EXISTS destination") == 1:
+            validation = self.validate_temp(target, info, dest_key, sample_offsets, full_offsets)
+            entry["validation"] = validation
+            entry["state"] = "committed"
+            entry["committed_at_ms"] = now_ms()
+            entry["error"] = None
+            self.manifest.upsert(entry)
+            self.summary["resumed"] += 1
+            print(f"RESUMED db={info.db} key={key_to_text(info.key)} from destination key")
+            return True
+
+        return False
+
+    def detect_source(self, source: RedisClient, db: int, key: bytes) -> Optional[SourceInfo]:
+        if parse_uint(source.execute(["EXISTS", key]), "EXISTS") == 0:
+            return None
+        candidates = []
+        if self.args.source_type in {"auto", "reroaring"}:
+            candidates.append(("reroaring", "R"))
+        if self.args.source_type in {"auto", "roaring64"}:
+            candidates.append(("roaring64", "R64"))
+
+        last_wrongtype: Optional[RedisError] = None
+        for source_type, prefix in candidates:
+            try:
+                cardinality = parse_uint(source.execute([f"{prefix}.BITCOUNT", key]), "cardinality")
+                min_offset = parse_offset_or_minus_one(source.execute([f"{prefix}.MIN", key]), "min offset")
+                max_offset = parse_offset_or_minus_one(source.execute([f"{prefix}.MAX", key]), "max offset")
+                expire_at_ms, ttl_ms = self.read_expire(source, key)
+                if ttl_ms == -2:
+                    return None
+                source_hash = self.source_payload_hash(source, key)
+                return SourceInfo(
+                    db=db,
+                    key=key,
+                    source_type=source_type,
+                    command_prefix=prefix,
+                    cardinality=cardinality,
+                    min_offset=min_offset,
+                    max_offset=max_offset,
+                    expire_at_ms=expire_at_ms,
+                    ttl_ms=ttl_ms,
+                    source_hash=source_hash,
+                )
+            except RedisError as exc:
+                if is_wrongtype_error(exc):
+                    last_wrongtype = exc
+                    continue
+                if is_unknown_command_error(exc):
+                    raise MigrateError(f"source redis-roaring command {prefix}.BITCOUNT is unavailable: {exc}")
+                raise
+        if self.args.source_type != "auto" and last_wrongtype is not None:
+            raise MigrateError(f"key is not {self.args.source_type}: {last_wrongtype}")
+        return None
+
+    def read_expire(self, source: RedisClient, key: bytes) -> tuple[Optional[int], int]:
+        try:
+            expire_at = int(source.execute(["PEXPIRETIME", key]))
+            if expire_at > 0:
+                return expire_at, max(expire_at - now_ms(), 0)
+            return None, expire_at
+        except RedisError as exc:
+            if not is_unknown_command_error(exc):
+                raise
+        ttl = int(source.execute(["PTTL", key]))
+        if ttl > 0:
+            return now_ms() + ttl, ttl
+        return None, ttl
+
+    def source_payload_hash(self, source: RedisClient, key: bytes) -> Optional[str]:
+        try:
+            payload = source.execute(["DUMP", key])
+        except RedisError:
+            return None
+        if payload is None:
+            return None
+        if not isinstance(payload, bytes):
+            payload = str(payload).encode("utf-8")
+        return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    def import_to_temp(
+        self,
+        source: RedisClient,
+        target: RedisClient,
+        info: SourceInfo,
+        build_key: bytes,
+        temp_key: bytes,
+    ) -> tuple[set[int], Optional[set[int]]]:
+        sample_ranks = self.sample_ranks(info.cardinality)
+        sample_offsets: set[int] = set()
+        full_offsets: Optional[set[int]] = set() if info.cardinality <= self.args.full_diff_limit else None
+        exported_count = 0
+        last_offset: Optional[int] = None
+
+        with source.connection() as src, target.connection() as dst:
+            dst.command(["DEL", build_key, temp_key])
+            if info.cardinality == 0:
+                dst.command(["SET", build_key, b""])
+            else:
+                dst.command(["SETBIT", build_key, "0", "0"])
+            dst.command(["BITMAP", "CONVERT", build_key, "NATIVE"])
+
+            if info.cardinality:
+                for rank_start in range(0, info.cardinality, self.args.page_size):
+                    rank_end = min(info.cardinality - 1, rank_start + self.args.page_size - 1)
+                    raw_offsets = src.command([
+                        f"{info.command_prefix}.RANGEINTARRAY",
+                        info.key,
+                        str(rank_start),
+                        str(rank_end),
+                    ])
+                    if not isinstance(raw_offsets, list):
+                        raise MigrateError(f"unexpected RANGEINTARRAY reply for {key_to_text(info.key)}")
+                    expected = rank_end - rank_start + 1
+                    if len(raw_offsets) != expected:
+                        raise MigrateError(
+                            f"source changed while exporting {key_to_text(info.key)}: "
+                            f"expected {expected} offsets, got {len(raw_offsets)}"
+                        )
+                    offsets = [parse_uint(offset, "offset") for offset in raw_offsets]
+                    commands: list[list[Any]] = []
+                    for i, offset in enumerate(offsets):
+                        if offset > NATIVE_V1_MAX_BIT:
+                            raise MigrateError(f"offset {offset} exceeds v1 native bitmap cap")
+                        if last_offset is not None and offset <= last_offset:
+                            raise MigrateError(f"source offsets are not strictly increasing at {offset}")
+                        absolute_rank = rank_start + i
+                        if absolute_rank in sample_ranks:
+                            sample_offsets.add(offset)
+                        if full_offsets is not None:
+                            full_offsets.add(offset)
+                        commands.append(["SETBIT", build_key, str(offset), "1"])
+                        last_offset = offset
+                    self.send_in_chunks(dst, commands, self.args.pipeline_size)
+                    exported_count += len(offsets)
+
+            if exported_count != info.cardinality:
+                raise MigrateError(
+                    f"exported {exported_count} offsets from {key_to_text(info.key)}, "
+                    f"expected {info.cardinality}"
+                )
+
+            current_count = parse_uint(src.command([f"{info.command_prefix}.BITCOUNT", info.key]), "cardinality")
+            if current_count != info.cardinality:
+                raise MigrateError(
+                    f"source cardinality changed during export for {key_to_text(info.key)}: "
+                    f"{info.cardinality} -> {current_count}"
+                )
+
+            payload = dst.command(["DUMP", build_key])
+            if payload is None:
+                raise MigrateError("target DUMP returned nil for build key")
+            restore_cmd: list[Any]
+            if info.expire_at_ms is not None:
+                restore_cmd = ["RESTORE", temp_key, str(info.expire_at_ms), payload, "REPLACE", "ABSTTL"]
+            else:
+                restore_cmd = ["RESTORE", temp_key, "0", payload, "REPLACE"]
+            dst.command(restore_cmd)
+            dst.command(["DEL", build_key])
+
+        if info.cardinality and not sample_offsets:
+            sample_offsets.add(info.min_offset)
+            sample_offsets.add(info.max_offset)
+        return sample_offsets, full_offsets
+
+    def send_in_chunks(self, conn: RespConnection, commands: list[list[Any]], chunk_size: int) -> None:
+        for start in range(0, len(commands), chunk_size):
+            conn.send_pipeline(commands[start:start + chunk_size])
+
+    def sample_ranks(self, cardinality: int) -> set[int]:
+        if cardinality <= 0:
+            return set()
+        count = min(cardinality, self.args.sample_count)
+        if count == 1:
+            return {0}
+        return {round(i * (cardinality - 1) / (count - 1)) for i in range(count)}
+
+    def validate_temp(
+        self,
+        target: RedisClient,
+        info: SourceInfo,
+        temp_key: bytes,
+        sample_offsets: set[int],
+        full_offsets: Optional[set[int]],
+    ) -> dict[str, Any]:
+        checks: dict[str, Any] = {}
+        with target.connection() as conn:
+            key_type = decode_text(conn.command(["TYPE", temp_key])).lower()
+            checks["type"] = key_type
+            if key_type != "bitmap":
+                raise MigrateError(f"temporary key type is {key_type!r}, expected 'bitmap'")
+            cardinality = parse_uint(conn.command(["BITCOUNT", temp_key]), "target cardinality")
+            checks["cardinality"] = cardinality
+            if cardinality != info.cardinality:
+                raise MigrateError(f"target cardinality {cardinality} != source {info.cardinality}")
+            bitpos = int(conn.command(["BITPOS", temp_key, "1"]))
+            checks["bitpos_1"] = bitpos
+            expected_min = -1 if info.cardinality == 0 else info.min_offset
+            if bitpos != expected_min:
+                raise MigrateError(f"target BITPOS 1 {bitpos} != source min {expected_min}")
+            if info.cardinality == 0:
+                bitpos_zero = int(conn.command(["BITPOS", temp_key, "0"]))
+                checks["bitpos_0"] = bitpos_zero
+                if bitpos_zero != -1:
+                    raise MigrateError(f"target BITPOS 0 {bitpos_zero} != empty native bitmap -1")
+            else:
+                if parse_uint(conn.command(["GETBIT", temp_key, str(info.min_offset)]), "GETBIT min") != 1:
+                    raise MigrateError("target min offset is not set")
+                if parse_uint(conn.command(["GETBIT", temp_key, str(info.max_offset)]), "GETBIT max") != 1:
+                    raise MigrateError("target max offset is not set")
+                if info.min_offset > 0:
+                    before_min = parse_uint(conn.command(["GETBIT", temp_key, str(info.min_offset - 1)]), "GETBIT before min")
+                    if before_min != 0:
+                        raise MigrateError("target has a bit set before source min")
+                if info.max_offset < NATIVE_V1_MAX_BIT:
+                    after_max = parse_uint(conn.command(["GETBIT", temp_key, str(info.max_offset + 1)]), "GETBIT after max")
+                    if after_max != 0:
+                        raise MigrateError("target has a bit set after source max")
+            for offset in sorted(sample_offsets):
+                if parse_uint(conn.command(["GETBIT", temp_key, str(offset)]), "GETBIT sample") != 1:
+                    raise MigrateError(f"target sampled offset {offset} is not set")
+            if full_offsets is not None:
+                for offset in sorted(full_offsets):
+                    if parse_uint(conn.command(["GETBIT", temp_key, str(offset)]), "GETBIT diff") != 1:
+                        raise MigrateError(f"target offset {offset} is missing from full diff check")
+                if len(full_offsets) != cardinality:
+                    raise MigrateError("full diff offset count does not match target cardinality")
+            target_ttl = int(conn.command(["PTTL", temp_key]))
+            checks["ttl_ms"] = target_ttl
+            if info.expire_at_ms is not None and target_ttl < 0:
+                raise MigrateError("temporary key lost source TTL")
+        return checks
+
+    def commit_temp(self, target: RedisClient, dest_key: bytes, temp_key: bytes) -> None:
+        with target.connection() as conn:
+            exists = parse_uint(conn.command(["EXISTS", dest_key]), "EXISTS destination")
+            if exists and not self.args.replace:
+                conn.command(["DEL", temp_key])
+                raise MigrateError(f"destination key already exists: {key_to_text(dest_key)} (use --replace)")
+            if parse_uint(conn.command(["EXISTS", temp_key]), "EXISTS temp") != 1:
+                raise MigrateError(f"temporary key is missing before commit: {key_to_text(temp_key)}")
+            if self.args.replace:
+                conn.command(["RENAME", temp_key, dest_key])
+                return
+            renamed = parse_uint(conn.command(["RENAMENX", temp_key, dest_key]), "RENAMENX")
+            if renamed != 1:
+                conn.command(["DEL", temp_key])
+                raise MigrateError(f"destination key already exists: {key_to_text(dest_key)}")
+
+    def record_failure(self, db: int, key: bytes, error: str) -> None:
+        entry_id = self.entry_id(db, key)
+        entry = self.manifest.get(entry_id) or {
+            "id": entry_id,
+            "db": db,
+            "key": key_to_text(key),
+            "key_b64": key_to_b64(key),
+        }
+        already_failed = entry.get("state") == "failed"
+        entry["state"] = "failed"
+        entry["error"] = error
+        if not already_failed:
+            self.summary["failed"] += 1
+        self.manifest.upsert(entry)
+        print(f"FAILED db={db} key={key_to_text(key)}: {error}", file=sys.stderr)
+
+    def base_entry(self, info: SourceInfo, dest_key: bytes, build_key: bytes, temp_key: bytes) -> dict[str, Any]:
+        return {
+            "id": self.entry_id(info.db, info.key),
+            "state": "planned",
+            "db": info.db,
+            "key": key_to_text(info.key),
+            "key_b64": key_to_b64(info.key),
+            "destination_key": key_to_text(dest_key),
+            "destination_key_b64": key_to_b64(dest_key),
+            "temporary_key": key_to_text(temp_key),
+            "temporary_key_b64": key_to_b64(temp_key),
+            "build_key": key_to_text(build_key),
+            "build_key_b64": key_to_b64(build_key),
+            "source_type": info.source_type,
+            "ttl_ms": info.ttl_ms,
+            "expire_at_ms": info.expire_at_ms,
+            "cardinality": info.cardinality,
+            "min_offset": info.min_offset,
+            "max_offset": info.max_offset,
+            "max_observed_offset": info.max_offset,
+            "source_hash": info.source_hash,
+            "overwrite_policy": "replace" if self.args.replace else "no-overwrite",
+            "cap_policy": self.args.cap_policy,
+            "error": None,
+        }
+
+    def destination_key(self, key: bytes) -> bytes:
+        return self.args.target_prefix.encode("utf-8") + key + self.args.target_suffix.encode("utf-8")
+
+    def manifest_key(self, db: int, key: bytes, suffix: bytes) -> bytes:
+        digest = hashlib.sha256(str(db).encode("ascii") + b":" + key).hexdigest().encode("ascii")
+        return b"__redis-bitmap-migrate:" + digest + b":" + suffix
+
+    def entry_id(self, db: int, key: bytes) -> str:
+        digest = hashlib.sha256(key).hexdigest()
+        return f"db{db}:{digest}"
+
+    def print_summary(self) -> None:
+        print(
+            "summary: "
+            f"scanned={self.summary['scanned']} "
+            f"planned={self.summary['planned']} "
+            f"migrated={self.summary['migrated']} "
+            f"skipped={self.summary['skipped']} "
+            f"non_roaring={self.summary['non_roaring']} "
+            f"failed={self.summary['failed']} "
+            f"resumed={self.summary['resumed']}"
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Migrate redis-roaring R.* / R64.* module keys into native Redis bitmap "
+            "values using an external streaming workflow."
+        )
+    )
+    parser.add_argument("--source-host", default="127.0.0.1")
+    parser.add_argument("--source-port", type=int, default=6379)
+    parser.add_argument("--source-user")
+    parser.add_argument("--source-password")
+    parser.add_argument("--target-host", default="127.0.0.1")
+    parser.add_argument("--target-port", type=int, default=6380)
+    parser.add_argument("--target-user")
+    parser.add_argument("--target-password")
+    parser.add_argument("--db", type=int, action="append", help="DB index to migrate; repeatable")
+    parser.add_argument("--all-dbs", action="store_true", help="discover DBs from INFO keyspace")
+    parser.add_argument("--pattern", default="*", help="SCAN MATCH pattern")
+    parser.add_argument("--key", action="append", help="specific UTF-8 key to migrate; repeatable")
+    parser.add_argument("--key-file", help="newline-delimited binary-safe key file")
+    parser.add_argument("--source-type", choices=("auto", "reroaring", "roaring64"), default="auto")
+    parser.add_argument("--target-prefix", default="", help="prefix to add to destination keys")
+    parser.add_argument("--target-suffix", default="", help="suffix to add to destination keys")
+    parser.add_argument("--manifest", default="redis-bitmap-migrate-manifest.json")
+    parser.add_argument("--resume", action="store_true", help="resume from an existing manifest")
+    parser.add_argument("--apply", action="store_true", help="perform writes; default is dry-run")
+    parser.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--assume-frozen", action="store_true", help="confirm source writes are frozen for this pass")
+    parser.add_argument(
+        "--allow-live-copy",
+        action="store_true",
+        help="allow an initial live copy pass; final correctness still requires a later frozen/verified pass",
+    )
+    parser.add_argument("--replace", action="store_true", help="overwrite existing destination keys")
+    parser.add_argument("--cap-policy", choices=("fail", "skip"), default="fail")
+    parser.add_argument("--strict-scan", action="store_true", help="fail when scanned keys are not redis-roaring values")
+    parser.add_argument("--keep-going", action="store_true", help="continue after per-key migration errors")
+    parser.add_argument("--scan-count", type=int, default=1000)
+    parser.add_argument("--page-size", type=int, default=10000)
+    parser.add_argument("--pipeline-size", type=int, default=1000)
+    parser.add_argument("--sample-count", type=int, default=64)
+    parser.add_argument("--full-diff-limit", type=int, default=10000)
+    parser.add_argument("--socket-timeout", type=float, default=30.0)
+    parser.add_argument("--allow-cluster", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    if args.apply and args.dry_run:
+        raise MigrateError("--apply and --dry-run are mutually exclusive")
+    args.dry_run = not args.apply
+    if args.page_size <= 0:
+        raise MigrateError("--page-size must be positive")
+    if args.pipeline_size <= 0:
+        raise MigrateError("--pipeline-size must be positive")
+    if args.sample_count < 0:
+        raise MigrateError("--sample-count must not be negative")
+    if args.full_diff_limit < 0:
+        raise MigrateError("--full-diff-limit must not be negative")
+    if args.all_dbs and args.db:
+        raise MigrateError("--all-dbs cannot be combined with --db")
+    if args.db is None:
+        args.db = [0]
+    return args
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        return BitmapMigrator(args).run()
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+    except MigrateError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `tools/redis-bitmap-migrate.py` as the redis-roaring-owned external migrator for `R.*` / `R64.*` keys
- add Python integration tests that exercise the public-command migration contract with fake RESP servers and optional real Redis/native-bitmap targets
- wire a CI job for py_compile plus the default migrator contract suite
- document dry-run/apply usage and the env vars for real native-target testing

Fixes aviggiano/redis#134.
