### PR TITLE
Fix SETBIT ignoring the value argument on a missing key

### DIFF
--- a/src/r_32.c
+++ b/src/r_32.c
@@ -239,8 +239,12 @@ int RSetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
 
   /* Create an empty value object if the key is currently empty. */
   if (bitmap == BITMAP_NILL) {
-    uint32_t values[] = { offset };
-    bitmap = bitmap_from_int_array(1, values);
+    if (value) {
+      uint32_t values[] = { offset };
+      bitmap = bitmap_from_int_array(1, values);
+    } else {
+      bitmap = bitmap_alloc();
+    }
     RedisModule_ModuleTypeSetValue(key, BitmapType, bitmap);
     RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithLongLong(ctx, 0);

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -174,8 +174,12 @@ int R64SetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
 
   /* Create an empty value object if the key is currently empty. */
   if (bitmap == BITMAP64_NILL) {
-    uint64_t values[] = { offset };
-    bitmap = bitmap64_from_int_array(1, values);
+    if (value) {
+      uint64_t values[] = { offset };
+      bitmap = bitmap64_from_int_array(1, values);
+    } else {
+      bitmap = bitmap64_alloc();
+    }
     RedisModule_ModuleTypeSetValue(key, Bitmap64Type, bitmap);
     RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithLongLong(ctx, 0);

--- a/tests/integration_1.sh
+++ b/tests/integration_1.sh
@@ -16,6 +16,10 @@ function test_setbit_getbit() {
   rcall_assert "R.GETBIT test_setbit_getbit 0" "1" "Get bit at position 0"
 
   rcall_assert "R.SETBIT test_setbit_getbit 0" "ERR wrong number of arguments for 'R.SETBIT' command" "SETBIT with wrong number of arguments"
+
+  rcall_assert "R.SETBIT test_setbit_zero_new 5 0" "0" "SETBIT with value 0 on a missing key"
+  rcall_assert "R.GETBIT test_setbit_zero_new 5" "0" "Bit stays clear after SETBIT 0 on a missing key"
+  rcall_assert "R.BITCOUNT test_setbit_zero_new" "0" "Bitmap created by SETBIT 0 is empty"
   rcall_assert "R.GETBIT key 0 1" "ERR wrong number of arguments for 'R.GETBIT' command" "GETBIT with wrong number of arguments"
 }
 

--- a/tests/integration_3.sh
+++ b/tests/integration_3.sh
@@ -17,6 +17,10 @@ function test_setbit_getbit() {
 
   rcall_assert "R64.SETBIT test_setbit_getbit 0" "ERR wrong number of arguments for 'R64.SETBIT' command" "SETBIT with wrong number of arguments"
   rcall_assert "R64.GETBIT key 0 1" "ERR wrong number of arguments for 'R64.GETBIT' command" "GETBIT with wrong number of arguments"
+
+  rcall_assert "R64.SETBIT test_setbit_zero_new 5 0" "0" "SETBIT with value 0 on a missing key"
+  rcall_assert "R64.GETBIT test_setbit_zero_new 5" "0" "Bit stays clear after SETBIT 0 on a missing key"
+  rcall_assert "R64.BITCOUNT test_setbit_zero_new" "0" "Bitmap created by SETBIT 0 is empty"
 }
 
 function test_getbits() {


### PR DESCRIPTION
## Bug

`R.SETBIT` / `R64.SETBIT` on a key that does not exist yet create the bitmap directly from the offset without consulting the `value` argument — so setting a bit to `0` on a fresh key actually sets it to `1`:

```
127.0.0.1:6379> R.SETBIT mykey 5 0
(integer) 0
127.0.0.1:6379> R.GETBIT mykey 5
(integer) 1        # expected 0
127.0.0.1:6379> R.BITCOUNT mykey
(integer) 1        # expected 0
```

Reproducible on the published image (`docker run -p 6379:6379 aviggiano/redis-roaring`). The 64-bit variant behaves the same way.

## Root cause

The missing-key fast path in `RSetBitCommand` (`src/r_32.c`) builds the new bitmap unconditionally from the offset:

```c
if (bitmap == BITMAP_NILL) {
  uint32_t values[] = { offset };
  bitmap = bitmap_from_int_array(1, values);
  ...
```

`R64SetBitCommand` in `src/r_64.c` has the identical pattern.

## Fix

The missing-key path now includes the offset only when `value` is `1`, and creates an empty bitmap otherwise — consistent with how the existing-key path treats `value`. The reply (`0`, the prior bit value) is unchanged, as is key creation itself.

Integration tests added to `test_setbit_getbit` in both `tests/integration_1.sh` and `tests/integration_3.sh` covering the missing-key + value `0` case (bit stays clear, cardinality 0).

Verified by loading the rebuilt module and exercising the repro above plus the neighboring paths (create with `1`, clear on an existing key).