### PR TITLE
Fix SETBIT on a missing key, AOF rewrite data loss, and the red migrator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aviggiano/redis
-        # Pinned so a change in the native fork cannot turn this repository's
-        # CI red on its own. Bump deliberately, re-running the migrator tests:
+        # Deliberately tracks the branch Redis core goes live on, so this job is
+        # the early warning that the native bitmap encoding moved. When it goes
+        # red on a commit that did not touch this repository, that is the signal:
         # the seed payload in tools/redis-bitmap-migrate.py encodes the fork's
-        # RDB type id and layout for native bitmaps.
-        ref: 00bea6dcd415061a41e899e7a6728ef2c54425e0
+        # RDB type id and layout for native bitmaps and needs regenerating. The
+        # migrator's preflight names that remedy explicitly rather than failing
+        # per key with "Bad data format".
+        ref: unstable
         path: native-redis
         submodules: recursive
     - name: Compile migrator and benchmark harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       run: python3 -m py_compile tools/redis-bitmap-migrate.py tests/integration/redis-bitmap-migrate.py tools/bitmap-bench.py
     - name: Run migrator contract tests
       run: python3 tests/integration/redis-bitmap-migrate.py
-    - name: Build native Redis unstable
+    - name: Build native Redis
       run: make -C native-redis -j"$(nproc)"
     - name: Build redis-roaring module
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aviggiano/redis
-        ref: unstable
+        # Pinned so a change in the native fork cannot turn this repository's
+        # CI red on its own. Bump deliberately, re-running the migrator tests:
+        # the seed payload in tools/redis-bitmap-migrate.py encodes the fork's
+        # RDB type id and layout for native bitmaps.
+        ref: 00bea6dcd415061a41e899e7a6728ef2c54425e0
         path: native-redis
         submodules: recursive
     - name: Compile migrator and benchmark harness

--- a/docs/redis-upstreaming/redis-roaring-migration-contract.md
+++ b/docs/redis-upstreaming/redis-roaring-migration-contract.md
@@ -105,6 +105,14 @@ it creates a tiny native build key on the target Redis, streams exported offsets
 into that native key with `SETBIT`, obtains the target-generated `DUMP` payload,
 and `RESTORE`s that payload into the manifest temp key before validation.
 
+The build key itself is seeded by restoring a constant empty native bitmap
+payload, so the target's `bitmap-default-roaring` setting cannot change the
+resulting type. That constant encodes the target's RDB type id for native
+bitmaps and its payload layout, so it must be regenerated from a `DUMP` of an
+empty native bitmap whenever either changes. An `--apply` run probes the
+constant once during preflight and fails with that instruction rather than
+reporting an opaque per-key `Bad data format`.
+
 After import, the tool validates the temporary key before finalizing. Finalizing
 uses an atomic rename or replace into the destination key. The tool must preserve
 the source DB index and TTL, preferably as an absolute expire time in the

--- a/docs/redis-upstreaming/redis-roaring-migration-contract.md
+++ b/docs/redis-upstreaming/redis-roaring-migration-contract.md
@@ -109,9 +109,17 @@ The build key itself is seeded by restoring a constant empty native bitmap
 payload, so the target's `bitmap-default-roaring` setting cannot change the
 resulting type. That constant encodes the target's RDB type id for native
 bitmaps and its payload layout, so it must be regenerated from a `DUMP` of an
-empty native bitmap whenever either changes. An `--apply` run probes the
-constant once during preflight and fails with that instruction rather than
-reporting an opaque per-key `Bad data format`.
+empty native bitmap whenever either changes. Lower the RDB version field of a
+regenerated payload back to the oldest target version that must keep working:
+`RESTORE` rejects a payload whose version exceeds the target's own.
+
+An `--apply` run probes the constant once per database during preflight and
+fails with that instruction rather than reporting an opaque per-key
+`Bad data format`. The probe writes and immediately deletes the reserved key
+`__bitmap_migrate_seed_probe__` in each database the run will migrate, never in
+a database that is out of scope, and it refuses to run at all if that name is
+already taken rather than overwriting it. A dry run never writes to the target,
+so it cannot detect a stale payload; only `--apply` reports one.
 
 After import, the tool validates the temporary key before finalizing. Finalizing
 uses an atomic rename or replace into the destination key. The tool must preserve

--- a/src/data-structure.c
+++ b/src/data-structure.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <limits.h>
 #include <math.h>
 #include "data-structure.h"
@@ -1060,7 +1061,7 @@ static inline int bitmap_stat_json(const Bitmap* bitmap, char** result) {
   return asprintf(result,
     "{"
     "\"type\":\"bitmap\","
-    "\"cardinality\":\"%llu\","
+    "\"cardinality\":\"%" PRIu64 "\","
     "\"number_of_containers\":\"%u\","
     "\"max_value\":\"%u\","
     "\"min_value\":\"%u\","
@@ -1099,7 +1100,7 @@ static inline int bitmap_stat_plain(const Bitmap* bitmap, char** result) {
 
   return asprintf(result,
     "type: bitmap\n"
-    "cardinality: %llu\n"
+    "cardinality: %" PRIu64 "\n"
     "number of containers: %u\n"
     "max value: %u\n"
     "min value: %u\n"
@@ -1174,22 +1175,22 @@ static inline int bitmap64_stat_json(const Bitmap64* bitmap, char** result) {
   return asprintf(result,
     "{"
     "\"type\":\"bitmap64\","
-    "\"cardinality\":\"%llu\","
-    "\"number_of_containers\":\"%llu\","
-    "\"max_value\":\"%llu\","
-    "\"min_value\":\"%llu\","
+    "\"cardinality\":\"%" PRIu64 "\","
+    "\"number_of_containers\":\"%" PRIu64 "\","
+    "\"max_value\":\"%" PRIu64 "\","
+    "\"min_value\":\"%" PRIu64 "\","
     "\"array_container\":{"
-    "\"number_of_containers\":\"%llu\","
-    "\"container_cardinality\":\"%llu\","
-    "\"container_allocated_bytes\":\"%llu\"},"
+    "\"number_of_containers\":\"%" PRIu64 "\","
+    "\"container_cardinality\":\"%" PRIu64 "\","
+    "\"container_allocated_bytes\":\"%" PRIu64 "\"},"
     "\"bitset_container\":{"
-    "\"number_of_containers\":\"%llu\","
-    "\"container_cardinality\":\"%llu\","
-    "\"container_allocated_bytes\":\"%llu\"},"
+    "\"number_of_containers\":\"%" PRIu64 "\","
+    "\"container_cardinality\":\"%" PRIu64 "\","
+    "\"container_allocated_bytes\":\"%" PRIu64 "\"},"
     "\"run_container\":{"
-    "\"number_of_containers\":\"%llu\","
-    "\"container_cardinality\":\"%llu\","
-    "\"container_allocated_bytes\":\"%llu\"}"
+    "\"number_of_containers\":\"%" PRIu64 "\","
+    "\"container_cardinality\":\"%" PRIu64 "\","
+    "\"container_allocated_bytes\":\"%" PRIu64 "\"}"
     "}",
     roaring64_bitmap_get_cardinality(bitmap),
     stats.n_containers,
@@ -1213,19 +1214,19 @@ static inline int bitmap64_stat_plain(const Bitmap64* bitmap, char** result) {
 
   return asprintf(result,
     "type: bitmap64\n"
-    "cardinality: %llu\n"
-    "number of containers: %llu\n"
-    "max value: %llu\n"
-    "min value: %llu\n"
-    "number of array containers: %llu\n"
-    "\tarray container values: %llu\n"
-    "\tarray container bytes: %llu\n"
-    "bitset  containers: %llu\n"
-    "\tbitset  container values: %llu\n"
-    "\tbitset  container bytes: %llu\n"
-    "run containers: %llu\n"
-    "\trun container values: %llu\n"
-    "\trun container bytes: %llu\n"
+    "cardinality: %" PRIu64 "\n"
+    "number of containers: %" PRIu64 "\n"
+    "max value: %" PRIu64 "\n"
+    "min value: %" PRIu64 "\n"
+    "number of array containers: %" PRIu64 "\n"
+    "\tarray container values: %" PRIu64 "\n"
+    "\tarray container bytes: %" PRIu64 "\n"
+    "bitset  containers: %" PRIu64 "\n"
+    "\tbitset  container values: %" PRIu64 "\n"
+    "\tbitset  container bytes: %" PRIu64 "\n"
+    "run containers: %" PRIu64 "\n"
+    "\trun container values: %" PRIu64 "\n"
+    "\trun container bytes: %" PRIu64 "\n"
     ,
     roaring64_bitmap_get_cardinality(bitmap),
     stats.n_containers,

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -127,12 +127,21 @@ typedef struct Bitmap_aof_rewrite_callback_params_s {
 
 static bool BitmapAofRewriteCallback(uint32_t offset, void* param) {
   Bitmap_aof_rewrite_callback_params* params = param;
-  RedisModule_EmitAOF(params->aof, "R.SETBIT", "sll", params->key, offset, 1);
+  RedisModule_EmitAOF(params->aof, "R.SETBIT", "sll", params->key, (long long) offset, 1LL);
   return true;
 }
 
 void BitmapAofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value) {
   Bitmap* bitmap = value;
+
+  /* An empty bitmap has no bits to emit, but the key still exists and must
+   * survive the rewrite: recreate it by setting a bit and clearing it again. */
+  if (roaring_bitmap_get_cardinality(bitmap) == 0) {
+    RedisModule_EmitAOF(aof, "R.SETBIT", "sll", key, 0LL, 1LL);
+    RedisModule_EmitAOF(aof, "R.SETBIT", "sll", key, 0LL, 0LL);
+    return;
+  }
+
   Bitmap_aof_rewrite_callback_params params = {
       .aof = aof,
       .key = key

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -246,10 +246,16 @@ int RSetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
   bool value;
   ParseBoolOrReturn(ctx, argv[3], "value", value);
 
-  /* Create an empty value object if the key is currently empty. */
+  /* Create an empty value object if the key is currently empty. The offset is
+   * only included when the bit is being set, so that clearing a bit on a
+   * missing key leaves it clear, as it does on an existing bitmap. */
   if (bitmap == BITMAP_NILL) {
-    uint32_t values[] = { offset };
-    bitmap = bitmap_from_int_array(1, values);
+    if (value) {
+      uint32_t values[] = { offset };
+      bitmap = bitmap_from_int_array(1, values);
+    } else {
+      bitmap = bitmap_alloc();
+    }
     RedisModule_ModuleTypeSetValue(key, BitmapType, bitmap);
     RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithLongLong(ctx, 0);

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -1,4 +1,5 @@
 #include "r_32.h"
+#include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include "rmalloc.h"
@@ -120,33 +121,52 @@ void* BitmapRdbLoad(RedisModuleIO* rdb, int encver) {
   return bitmap;
 }
 
-typedef struct Bitmap_aof_rewrite_callback_params_s {
-  RedisModuleIO* aof;
-  RedisModuleString* key;
-} Bitmap_aof_rewrite_callback_params;
-
-static bool BitmapAofRewriteCallback(uint32_t offset, void* param) {
-  Bitmap_aof_rewrite_callback_params* params = param;
-  RedisModule_EmitAOF(params->aof, "R.SETBIT", "sll", params->key, (long long) offset, 1LL);
-  return true;
-}
+/* Number of values emitted per command when rewriting a bitmap into the AOF. */
+#define BITMAP_AOF_REWRITE_CHUNK 512
 
 void BitmapAofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value) {
   Bitmap* bitmap = value;
 
   /* An empty bitmap has no bits to emit, but the key still exists and must
-   * survive the rewrite: recreate it by setting a bit and clearing it again. */
+   * survive the rewrite. Clearing a bit on a key that does not exist creates it
+   * holding an empty bitmap (see RSetBitCommand), which is the state to restore.
+   * A single command keeps this atomic against a truncated AOF. */
   if (roaring_bitmap_get_cardinality(bitmap) == 0) {
-    RedisModule_EmitAOF(aof, "R.SETBIT", "sll", key, 0LL, 1LL);
     RedisModule_EmitAOF(aof, "R.SETBIT", "sll", key, 0LL, 0LL);
     return;
   }
 
-  Bitmap_aof_rewrite_callback_params params = {
-      .aof = aof,
-      .key = key
-  };
-  roaring_iterate(bitmap, BitmapAofRewriteCallback, &params);
+  roaring_uint32_iterator_t* iterator = roaring_iterator_create(bitmap);
+  if (iterator == NULL) {
+    RedisModule_LogIOError(aof, "warning", "Failed to iterate a bitmap while rewriting the AOF");
+    return;
+  }
+
+  RedisModuleCtx* ctx = RedisModule_GetContextFromIO(aof);
+  uint32_t values[BITMAP_AOF_REWRITE_CHUNK];
+  RedisModuleString* args[BITMAP_AOF_REWRITE_CHUNK];
+  bool first_chunk = true;
+  uint32_t read;
+
+  /* Emitted in chunks rather than one command per bit, to keep the rewritten
+   * AOF a reasonable size for large bitmaps. */
+  while (!RedisModule_IsIOError(aof) &&
+         (read = roaring_uint32_iterator_read(iterator, values, BITMAP_AOF_REWRITE_CHUNK)) > 0) {
+    for (uint32_t i = 0; i < read; i++) {
+      args[i] = RedisModule_CreateStringPrintf(ctx, "%" PRIu32, values[i]);
+    }
+
+    /* The first chunk creates the key, the following ones append to it. */
+    RedisModule_EmitAOF(aof, first_chunk ? "R.SETINTARRAY" : "R.APPENDINTARRAY",
+                        "sv", key, args, (size_t) read);
+    first_chunk = false;
+
+    for (uint32_t i = 0; i < read; i++) {
+      RedisModule_FreeString(ctx, args[i]);
+    }
+  }
+
+  roaring_uint32_iterator_free(iterator);
 }
 
 size_t BitmapMemUsage(const void* value) {
@@ -620,7 +640,7 @@ int RRangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int arg
   uint32_t range_size = (end - start) + 1;
 
   if (range_size > BITMAP_MAX_RANGE_SIZE) {
-    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, BITMAP_MAX_RANGE_SIZE);
+    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, (unsigned long long) BITMAP_MAX_RANGE_SIZE);
   }
 
   if (bitmap == BITMAP_NILL) {

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -1,4 +1,5 @@
 #include "r_64.h"
+#include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include "rmalloc.h"
@@ -129,25 +130,49 @@ void Bitmap64Free(void* value) {
   bitmap64_free(value);
 }
 
+/* Number of values emitted per command when rewriting a bitmap into the AOF. */
+#define BITMAP64_AOF_REWRITE_CHUNK 512
+
 void Bitmap64AofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value) {
   Bitmap64* bitmap = value;
 
-  uint64_t cardinality = bitmap64_get_cardinality(bitmap);
-  if (cardinality == 0) {
+  /* An empty bitmap has no values to emit, but the key still exists and must
+   * survive the rewrite: recreate it by setting a bit and clearing it again. */
+  if (bitmap64_get_cardinality(bitmap) == 0) {
+    RedisModule_EmitAOF(aof, "R64.SETBIT", "scc", key, "0", "1");
+    RedisModule_EmitAOF(aof, "R64.SETBIT", "scc", key, "0", "0");
     return;
   }
 
-  uint64_t* values = rm_malloc(sizeof(uint64_t) * cardinality);
-  if (values == NULL) {
+  roaring64_iterator_t* iterator = roaring64_iterator_create(bitmap);
+  if (iterator == NULL) {
     return;
   }
 
-  roaring64_bitmap_to_uint64_array(bitmap, values);
+  RedisModuleCtx* ctx = RedisModule_GetContextFromIO(aof);
+  uint64_t values[BITMAP64_AOF_REWRITE_CHUNK];
+  RedisModuleString* args[BITMAP64_AOF_REWRITE_CHUNK];
+  bool first_chunk = true;
+  uint64_t read;
 
-  /* Use R64.SETINTARRAY command to reconstruct the bitmap */
-  RedisModule_EmitAOF(aof, "R64.SETINTARRAY", "sl", key, values, cardinality);
+  /* Values do not fit the "l" (long long) specifier, so they are emitted as a
+   * vector of strings, in chunks, to keep each command a reasonable size. */
+  while ((read = roaring64_iterator_read(iterator, values, BITMAP64_AOF_REWRITE_CHUNK)) > 0) {
+    for (uint64_t i = 0; i < read; i++) {
+      args[i] = RedisModule_CreateStringPrintf(ctx, "%" PRIu64, values[i]);
+    }
 
-  rm_free(values);
+    /* The first chunk creates the key, the following ones append to it. */
+    RedisModule_EmitAOF(aof, first_chunk ? "R64.SETINTARRAY" : "R64.APPENDINTARRAY",
+                        "sv", key, args, (size_t) read);
+    first_chunk = false;
+
+    for (uint64_t i = 0; i < read; i++) {
+      RedisModule_FreeString(ctx, args[i]);
+    }
+  }
+
+  roaring64_iterator_free(iterator);
 }
 
 /**

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -137,15 +137,17 @@ void Bitmap64AofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value)
   Bitmap64* bitmap = value;
 
   /* An empty bitmap has no values to emit, but the key still exists and must
-   * survive the rewrite: recreate it by setting a bit and clearing it again. */
+   * survive the rewrite. Clearing a bit on a key that does not exist creates it
+   * holding an empty bitmap (see R64SetBitCommand), which is the state to
+   * restore. A single command keeps this atomic against a truncated AOF. */
   if (bitmap64_get_cardinality(bitmap) == 0) {
-    RedisModule_EmitAOF(aof, "R64.SETBIT", "scc", key, "0", "1");
     RedisModule_EmitAOF(aof, "R64.SETBIT", "scc", key, "0", "0");
     return;
   }
 
   roaring64_iterator_t* iterator = roaring64_iterator_create(bitmap);
   if (iterator == NULL) {
+    RedisModule_LogIOError(aof, "warning", "Failed to iterate a bitmap while rewriting the AOF");
     return;
   }
 
@@ -157,7 +159,8 @@ void Bitmap64AofRewrite(RedisModuleIO* aof, RedisModuleString* key, void* value)
 
   /* Values do not fit the "l" (long long) specifier, so they are emitted as a
    * vector of strings, in chunks, to keep each command a reasonable size. */
-  while ((read = roaring64_iterator_read(iterator, values, BITMAP64_AOF_REWRITE_CHUNK)) > 0) {
+  while (!RedisModule_IsIOError(aof) &&
+         (read = roaring64_iterator_read(iterator, values, BITMAP64_AOF_REWRITE_CHUNK)) > 0) {
     for (uint64_t i = 0; i < read; i++) {
       args[i] = RedisModule_CreateStringPrintf(ctx, "%" PRIu64, values[i]);
     }
@@ -443,7 +446,7 @@ int R64RangeIntArrayCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int a
   uint64_t range_size = (end - start) + 1;
 
   if (range_size > BITMAP64_MAX_RANGE_SIZE) {
-    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, BITMAP64_MAX_RANGE_SIZE);
+    return ReplyWithErrorFmt(ctx, ERRORMSG_RANGE_LIMIT, (unsigned long long) BITMAP64_MAX_RANGE_SIZE);
   }
 
   if (bitmap == BITMAP64_NILL) {

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -197,10 +197,16 @@ int R64SetBitCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
   bool value;
   ParseBoolOrReturn(ctx, argv[3], "value", value);
 
-  /* Create an empty value object if the key is currently empty. */
+  /* Create an empty value object if the key is currently empty. The offset is
+   * only included when the bit is being set, so that clearing a bit on a
+   * missing key leaves it clear, as it does on an existing bitmap. */
   if (bitmap == BITMAP64_NILL) {
-    uint64_t values[] = { offset };
-    bitmap = bitmap64_from_int_array(1, values);
+    if (value) {
+      uint64_t values[] = { offset };
+      bitmap = bitmap64_from_int_array(1, values);
+    } else {
+      bitmap = bitmap64_alloc();
+    }
     RedisModule_ModuleTypeSetValue(key, Bitmap64Type, bitmap);
     RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithLongLong(ctx, 0);

--- a/test.sh
+++ b/test.sh
@@ -88,7 +88,9 @@ function integration_4() {
 function integration_5() {
   stop_redis
   rm dump.rdb 2>/dev/null || true
+  # appendonlydir is Redis 7+; appendonly.aof is the 6.2 layout.
   rm -rf ./appendonlydir 2>/dev/null || true
+  rm -f appendonly.aof 2>/dev/null || true
 
   # Seed, rewrite the AOF, then reload it from a restarted server. The rewrite
   # runs without an RDB preamble so the module's aof_rewrite callbacks are used.
@@ -108,6 +110,7 @@ function integration_5() {
   ./tests/integration_5.sh verify
   stop_redis
   rm -rf ./appendonlydir 2>/dev/null || true
+  rm -f appendonly.aof 2>/dev/null || true
 
   echo "All integration (5) tests passed"
 }

--- a/test.sh
+++ b/test.sh
@@ -85,12 +85,40 @@ function integration_4() {
   echo "All integration (4) tests passed"
 }
 
+function integration_5() {
+  stop_redis
+  rm dump.rdb 2>/dev/null || true
+  rm -rf ./appendonlydir 2>/dev/null || true
+
+  # Seed, rewrite the AOF, then reload it from a restarted server. The rewrite
+  # runs without an RDB preamble so the module's aof_rewrite callbacks are used.
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind --aof --no-rdb-preamble
+  else
+    start_redis --aof --no-rdb-preamble
+  fi
+  ./tests/integration_5.sh seed
+  stop_redis
+
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind --aof --no-rdb-preamble
+  else
+    start_redis --aof --no-rdb-preamble
+  fi
+  ./tests/integration_5.sh verify
+  stop_redis
+  rm -rf ./appendonlydir 2>/dev/null || true
+
+  echo "All integration (5) tests passed"
+}
+
 setup
 unit
 integration_1
 integration_2
 integration_3
 integration_4
+integration_5
 
 echo ""
 echo "************************"

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -40,6 +40,12 @@ function start_redis() {
       --no-rdb-preamble)
         USE_RDB_PREAMBLE="no"
         ;;
+      *)
+        # Never silently drop a flag: a typo here would quietly downgrade a test
+        # to whatever the server defaults to.
+        echo "start_redis: unknown option '$PARAM'" >&2
+        return 1
+        ;;
     esac
     shift
   done
@@ -71,7 +77,7 @@ function start_redis() {
   export REDIS_PORT
 
   local REDIS_COMMAND="./deps/redis/src/redis-server --loglevel warning --loadmodule $LIB_PATH --port $REDIS_PORT"
-  local VALGRIND_COMMAND="valgrind --leak-check=yes --show-leak-kinds=definite,indirect --suppressions=./deps/redis/src/valgrind.sup --error-exitcode=1 --log-file=$LOG_FILE"
+  local VALGRIND_COMMAND="valgrind --leak-check=yes --show-leak-kinds=definite,indirect --child-silent-after-fork=yes --suppressions=./deps/redis/src/valgrind.sup --error-exitcode=1 --log-file=$LOG_FILE"
   local AOF_OPTION="--appendonly $USE_AOF --aof-use-rdb-preamble $USE_RDB_PREAMBLE"
   local CLUSTER_OPTION=""
   if [ "$USE_VALGRIND" == "no" ]; then
@@ -86,7 +92,13 @@ function start_redis() {
   eval "$VALGRIND_COMMAND" "$REDIS_COMMAND" "$AOF_OPTION" "$CLUSTER_OPTION" &
   REDIS_PID=$!
 
+  local READY_TRIES=0
   while [ "$(./deps/redis/src/redis-cli -p "$REDIS_PORT" PING 2>/dev/null)" != "PONG" ]; do
+    READY_TRIES=$((READY_TRIES + 1))
+    if [ "$READY_TRIES" -ge 600 ]; then
+      echo "Redis did not become ready on port $REDIS_PORT" >&2
+      return 1
+    fi
     sleep 0.1
   done
 }

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -21,6 +21,9 @@ function start_redis() {
   local USE_VALGRIND="no"
   local USE_AOF="no"
   local USE_CLUSTER="no"
+  # Rewriting the AOF with an RDB preamble stores module values through the RDB
+  # serializer, so the aof_rewrite callbacks only run when it is disabled.
+  local USE_RDB_PREAMBLE="yes"
   while [[ $# -gt 0 ]]; do
     local PARAM="$1"
     case $PARAM in
@@ -33,6 +36,9 @@ function start_redis() {
         ;;
       --cluster)
         USE_CLUSTER="yes"
+        ;;
+      --no-rdb-preamble)
+        USE_RDB_PREAMBLE="no"
         ;;
     esac
     shift
@@ -66,7 +72,7 @@ function start_redis() {
 
   local REDIS_COMMAND="./deps/redis/src/redis-server --loglevel warning --loadmodule $LIB_PATH --port $REDIS_PORT"
   local VALGRIND_COMMAND="valgrind --leak-check=yes --show-leak-kinds=definite,indirect --suppressions=./deps/redis/src/valgrind.sup --error-exitcode=1 --log-file=$LOG_FILE"
-  local AOF_OPTION="--appendonly $USE_AOF"
+  local AOF_OPTION="--appendonly $USE_AOF --aof-use-rdb-preamble $USE_RDB_PREAMBLE"
   local CLUSTER_OPTION=""
   if [ "$USE_VALGRIND" == "no" ]; then
     VALGRIND_COMMAND=""

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -1070,6 +1070,29 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                 # The run stops in preflight, before touching any key.
                 self.assertNotIn("FAILED db=0 key=foo", stderr)
 
+    def test_real_existing_probe_key_aborts_preflight_without_touching_it(self):
+        """Preflight must never clobber a target key that shares the probe name."""
+        probe_key = migrate.SEED_PROBE_KEY.decode()
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
+                source.execute(["R.SETBIT", "foo", "5", "1"])
+                target.execute(["SET", probe_key, "user data"])
+
+                rc, stdout, stderr = self.run_migrator(
+                    self.migrator_args(source_port, target_port, manifest, "foo")
+                )
+
+                self.assertEqual(rc, 1)
+                self.assertEqual(stdout, "")
+                self.assertIn("already exists on the target", stderr)
+                # The pre-existing key is untouched, not restored over and deleted.
+                self.assertEqual(target.execute(["EXISTS", probe_key]), 1)
+                self.assertEqual(target.execute(["GET", probe_key]), b"user data")
+
     def test_real_reroaring_rdb_snapshot_migrates_to_native_rdb(self):
         key = "snapshot:reroaring"
         bits = sorted({0, 7, 63, 64, 511, 4096, 65535})

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -541,6 +541,34 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             data = json.loads(manifest.read_text())
             self.assertEqual(data["entries"][0]["db"], 2)
 
+    def test_preflight_probe_runs_in_the_requested_db(self):
+        """The seed probe must not write to a database the run was not given."""
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={3, 9}) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, _stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--db", "2", "--key", "foo", "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(stderr, "")
+
+            # Every probe command must come after the SELECT that puts the
+            # connection in db 2, never on the default db 0 connection.
+            probe_positions = [
+                index for index, command in enumerate(servers.target.commands)
+                if len(command) > 1 and command[1] == migrate.SEED_PROBE_KEY
+            ]
+            self.assertTrue(probe_positions, "the preflight probe did not run")
+            select_positions = [
+                index for index, command in enumerate(servers.target.commands)
+                if command[:2] == [b"SELECT", b"2"]
+            ]
+            self.assertTrue(
+                select_positions,
+                "the preflight probe ran on the default db instead of db 2",
+            )
+            self.assertGreater(min(probe_positions), min(select_positions))
+
     def test_key_file_accepts_binary_key_names(self):
         key = b"bitmap:\xff native"
         with tempfile.TemporaryDirectory() as tmp, ServerPair(bits={key: {4, 12}}) as servers:
@@ -1052,6 +1080,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
             source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
             with source_proc, target_proc:
                 source = real_redis_client(source_port, "source")
+                target = real_redis_client(target_port, "target")
                 source.execute(["R.SETBIT", "foo", "5", "1"])
 
                 original = migrate.EMPTY_NATIVE_BITMAP_PAYLOAD
@@ -1069,6 +1098,10 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                 self.assertIn("EMPTY_NATIVE_BITMAP_PAYLOAD", stderr)
                 # The run stops in preflight, before touching any key.
                 self.assertNotIn("FAILED db=0 key=foo", stderr)
+                self.assertEqual(target.execute(["EXISTS", "foo"]), 0)
+                self.assertEqual(
+                    target.execute(["EXISTS", migrate.SEED_PROBE_KEY.decode()]), 0
+                )
 
     def test_real_existing_probe_key_aborts_preflight_without_touching_it(self):
         """Preflight must never clobber a target key that shares the probe name."""

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -79,8 +79,13 @@ class FakeRedisServer(socketserver.ThreadingTCPServer):
         bits=None,
         expire_at_ms=None,
         mutate_after_range=False,
+        deny_commands=None,
     ):
         self.mode = mode
+        self.deny_commands = {
+            name.upper().encode() if isinstance(name, str) else name.upper()
+            for name in (deny_commands or ())
+        }
         self.source_type = source_type
         if bits is None:
             self.bits = {b"foo": {1, 2, 5, 100}}
@@ -173,6 +178,8 @@ class FakeRedisHandler(socketserver.BaseRequestHandler):
         raise RuntimeError(f"unknown source command {name.decode()}")
 
     def target(self, command, name):
+        if name in self.server.deny_commands:
+            raise RuntimeError(f"NOPERM this user has no permissions to run the '{name.decode().lower()}' command")
         key = command[1] if len(command) > 1 else b""
         if name == b"EXISTS":
             return 1 if key in self.server.target else 0
@@ -303,6 +310,7 @@ class ServerPair:
         bits=None,
         expire_at_ms=None,
         mutate_after_range=False,
+        target_deny_commands=None,
     ):
         self.source = FakeRedisServer(
             "source",
@@ -313,7 +321,12 @@ class ServerPair:
             expire_at_ms=expire_at_ms,
             mutate_after_range=mutate_after_range,
         )
-        self.target = FakeRedisServer("target", ("127.0.0.1", 0), FakeRedisHandler)
+        self.target = FakeRedisServer(
+            "target",
+            ("127.0.0.1", 0),
+            FakeRedisHandler,
+            deny_commands=target_deny_commands,
+        )
         self.threads = [
             threading.Thread(target=self.source.serve_forever, daemon=True),
             threading.Thread(target=self.target.serve_forever, daemon=True),
@@ -568,6 +581,23 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 "the preflight probe ran on the default db instead of db 2",
             )
             self.assertGreater(min(probe_positions), min(select_positions))
+
+    def test_preflight_fails_when_it_cannot_delete_its_probe_key(self):
+        """A stranded probe key blocks every later run, so never pass silently."""
+        with tempfile.TemporaryDirectory() as tmp, ServerPair(
+            bits={3, 9}, target_deny_commands=["DEL"]
+        ) as servers:
+            manifest = Path(tmp) / "manifest.json"
+            rc, stdout, stderr = self.run_migrator(
+                servers.args(manifest, "--key", "foo", "--apply", "--assume-frozen")
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("could not delete its probe key", stderr)
+            self.assertIn("NOPERM", stderr)
+            # Preflight aborted, so nothing was migrated.
+            self.assertNotIn(b"foo", servers.target.target)
 
     def test_key_file_accepts_binary_key_names(self):
         key = b"bitmap:\xff native"

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -418,7 +418,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "2")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=4", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {1, 2, 5, 100})
@@ -436,7 +436,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "1")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {100, 200})
@@ -455,7 +455,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--apply", "--assume-frozen", "--page-size", "2")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=0", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], set())
@@ -487,7 +487,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--apply", "--assume-frozen")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {7, 9})
@@ -515,7 +515,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             manifest = Path(tmp) / "manifest.json"
             rc, stdout, stderr = self.run_migrator(servers.args(manifest, "--key", "foo"))
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("DRY-RUN db=0 key=foo type=reroaring count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target, {})
@@ -531,7 +531,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--db", "2", "--key", "foo", "--apply", "--assume-frozen")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=2 key=foo count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {3, 9})
@@ -549,7 +549,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--db", "2", "--key", "foo", "--apply", "--assume-frozen")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertEqual(stderr, "")
 
             # Every probe command must come after the SELECT that puts the
@@ -579,7 +579,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--key-file", str(key_file), "--apply", "--assume-frozen")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[key], {4, 12})
@@ -622,7 +622,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             manifest = Path(tmp) / "manifest.json"
             rc, stdout, stderr = self.run_migrator(servers.args(manifest, "--cap-policy", "skip"))
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("skipped=1", stdout)
             self.assertIn("SKIP db=0 key=foo", stderr)
             data = json.loads(manifest.read_text())
@@ -658,7 +658,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--apply", "--assume-frozen", "--replace")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=3", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {1, 2, 5})
@@ -713,7 +713,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--resume", "--apply", "--assume-frozen")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("RESUMED db=0 key=foo from temporary key", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {1, 2, 5, 100})
@@ -728,7 +728,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             rc, stdout, stderr = self.run_migrator(
                 servers.args(manifest, "--apply", "--allow-live-copy", "--page-size", "100")
             )
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=2", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {100, 200})
@@ -738,7 +738,7 @@ class RedisBitmapMigrateTests(unittest.TestCase):
                 servers.args(manifest, "--resume", "--apply", "--assume-frozen", "--page-size", "100")
             )
 
-            self.assertEqual(rc, 0)
+            self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
             self.assertIn("MIGRATED db=0 key=foo count=3", stdout)
             self.assertEqual(stderr, "")
             self.assertEqual(servers.target.target[b"foo"], {100, 200, 300})
@@ -747,10 +747,21 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             self.assertTrue(data["entries"][0]["source_writes_frozen"])
 
 
+# Ports handed out so far. Binding port 0 and closing the socket reserves
+# nothing, so without this two calls can legitimately return the same port and
+# the second server fails to bind.
+_HANDED_OUT_PORTS: set[int] = set()
+
+
 def free_tcp_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    for _ in range(50):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        if port not in _HANDED_OUT_PORTS:
+            _HANDED_OUT_PORTS.add(port)
+            return port
+    raise RuntimeError("could not find an unused TCP port")
 
 
 def redis_roaring_server_path():
@@ -1057,7 +1068,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     self.migrator_args(source_port, target_port, manifest, "foo")
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertIn("MIGRATED db=0 key=foo count=5", stdout)
                 self.assertEqual(stderr, "")
                 self.assert_native_bits(target, "foo", bits, {0, 3, 99, 65535})
@@ -1164,7 +1175,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     )
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertIn(f"MIGRATED db=0 key={key} count={len(bits)}", stdout)
                 self.assertEqual(stderr, "")
                 self.assert_native_dataset(target, key, bits)
@@ -1200,7 +1211,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     self.migrator_args(source_port, target_port, manifest, "wide")
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertIn("MIGRATED db=0 key=wide count=4", stdout)
                 self.assertEqual(stderr, "")
                 self.assert_native_bits(target, "wide", bits, {1, 64, 4097})
@@ -1236,7 +1247,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     )
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertIn(f"MIGRATED db=0 key=census1881 count={len(bits)}", stdout)
                 self.assertEqual(stderr, "")
                 self.assert_native_dataset(target, "census1881", bits)
@@ -1279,7 +1290,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     )
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertEqual(stderr, "")
                 for key, key_bits in datasets.items():
                     self.assertIn(f"MIGRATED db=0 key={key} count={len(key_bits)}", stdout)
@@ -1324,7 +1335,7 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
                     )
                 )
 
-                self.assertEqual(rc, 0)
+                self.assertEqual(rc, 0, f"migrator failed:\n{stderr}")
                 self.assertIn(f"MIGRATED db=0 key=census1881-64 count={len(bits)}", stdout)
                 self.assertEqual(stderr, "")
                 self.assert_native_dataset(target, "census1881-64", bits)

--- a/tests/integration/redis-bitmap-migrate.py
+++ b/tests/integration/redis-bitmap-migrate.py
@@ -496,9 +496,11 @@ class RedisBitmapMigrateTests(unittest.TestCase):
             restore_commands = [
                 command for command in servers.target.commands
                 if command and command[0].upper() == b"RESTORE"
+                and command[1] != migrate.SEED_PROBE_KEY
             ]
             # The first RESTORE seeds the empty native build key; the second
-            # installs the temporary key with the absolute TTL.
+            # installs the temporary key with the absolute TTL. The preflight
+            # seed probe is filtered out above.
             self.assertEqual(len(restore_commands), 2)
             self.assertEqual(restore_commands[0][3], migrate.EMPTY_NATIVE_BITMAP_PAYLOAD)
             self.assertEqual(restore_commands[1][2], str(expire_at).encode())
@@ -1041,6 +1043,32 @@ class RealRedisRoaringMigrationTests(unittest.TestCase):
             self.assertEqual(entry["source_type"], "reroaring")
             self.assertEqual(entry["cardinality"], len(bits))
             self.assertGreater(entry["validation"]["ttl_ms"], 0)
+
+    def test_real_stale_seed_payload_fails_preflight_with_actionable_error(self):
+        """A seed payload the target rejects must fail once, not per key."""
+        stale_payload = bytes.fromhex("1d00000f000000000000000000")
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            source_proc, target_proc, source_port, target_port = self.start_pair(tmp)
+            with source_proc, target_proc:
+                source = real_redis_client(source_port, "source")
+                source.execute(["R.SETBIT", "foo", "5", "1"])
+
+                original = migrate.EMPTY_NATIVE_BITMAP_PAYLOAD
+                migrate.EMPTY_NATIVE_BITMAP_PAYLOAD = stale_payload
+                try:
+                    rc, stdout, stderr = self.run_migrator(
+                        self.migrator_args(source_port, target_port, manifest, "foo")
+                    )
+                finally:
+                    migrate.EMPTY_NATIVE_BITMAP_PAYLOAD = original
+
+                self.assertEqual(rc, 1)
+                self.assertEqual(stdout, "")
+                self.assertIn("rejected the empty native bitmap seed payload", stderr)
+                self.assertIn("EMPTY_NATIVE_BITMAP_PAYLOAD", stderr)
+                # The run stops in preflight, before touching any key.
+                self.assertNotIn("FAILED db=0 key=foo", stderr)
 
     def test_real_reroaring_rdb_snapshot_migrates_to_native_rdb(self):
         key = "snapshot:reroaring"

--- a/tests/integration_1.sh
+++ b/tests/integration_1.sh
@@ -17,6 +17,17 @@ function test_setbit_getbit() {
 
   rcall_assert "R.SETBIT test_setbit_getbit 0" "ERR wrong number of arguments for 'R.SETBIT' command" "SETBIT with wrong number of arguments"
   rcall_assert "R.GETBIT key 0 1" "ERR wrong number of arguments for 'R.GETBIT' command" "GETBIT with wrong number of arguments"
+
+  # Clearing a bit on a key that does not exist yet must honour the value
+  # argument, the same way it does on an existing bitmap.
+  rcall_assert "R.SETBIT test_setbit_missing_key 5 0" "0" "Clear a bit on a missing key"
+  rcall_assert "EXISTS test_setbit_missing_key" "1" "Clearing a bit on a missing key still creates it"
+  rcall_assert "R.GETBIT test_setbit_missing_key 5" "0" "Bit stays clear on the created bitmap"
+  rcall_assert "R.BITCOUNT test_setbit_missing_key" "0" "Created bitmap is empty"
+
+  rcall_assert "R.SETBIT test_setbit_missing_key_set 5 1" "0" "Set a bit on a missing key"
+  rcall_assert "R.GETBIT test_setbit_missing_key_set 5" "1" "Bit is set on the created bitmap"
+  rcall_assert "R.BITCOUNT test_setbit_missing_key_set" "1" "Created bitmap holds the single bit"
 }
 
 function test_getbits() {

--- a/tests/integration_3.sh
+++ b/tests/integration_3.sh
@@ -17,6 +17,17 @@ function test_setbit_getbit() {
 
   rcall_assert "R64.SETBIT test_setbit_getbit 0" "ERR wrong number of arguments for 'R64.SETBIT' command" "SETBIT with wrong number of arguments"
   rcall_assert "R64.GETBIT key 0 1" "ERR wrong number of arguments for 'R64.GETBIT' command" "GETBIT with wrong number of arguments"
+
+  # Clearing a bit on a key that does not exist yet must honour the value
+  # argument, the same way it does on an existing bitmap.
+  rcall_assert "R64.SETBIT test_setbit_missing_key 5 0" "0" "Clear a bit on a missing key"
+  rcall_assert "EXISTS test_setbit_missing_key" "1" "Clearing a bit on a missing key still creates it"
+  rcall_assert "R64.GETBIT test_setbit_missing_key 5" "0" "Bit stays clear on the created bitmap"
+  rcall_assert "R64.BITCOUNT test_setbit_missing_key" "0" "Created bitmap is empty"
+
+  rcall_assert "R64.SETBIT test_setbit_missing_key_set 5 1" "0" "Set a bit on a missing key"
+  rcall_assert "R64.GETBIT test_setbit_missing_key_set 5" "1" "Bit is set on the created bitmap"
+  rcall_assert "R64.BITCOUNT test_setbit_missing_key_set" "1" "Created bitmap holds the single bit"
 }
 
 function test_getbits() {

--- a/tests/integration_5.sh
+++ b/tests/integration_5.sh
@@ -13,8 +13,23 @@ set -eu
 
 BIG_COUNT=1200
 
+# Prints the AOF the last rewrite produced: appendonlydir/*.base.aof on Redis 7+,
+# appendonly.aof on 6.2.
+function cat_rewritten_aof() {
+  if compgen -G "./appendonlydir/*.base.aof" > /dev/null; then
+    cat ./appendonlydir/*.base.aof
+  else
+    cat ./appendonly.aof
+  fi
+}
+
 function seed_bitmaps() {
   print_test_header "test_aof_rewrite_seed"
+
+  # Without this the rewrite stores module values through the RDB serializer and
+  # the aof_rewrite callbacks never run — every assertion below would then pass
+  # while testing nothing.
+  rcall_assert "CONFIG GET aof-use-rdb-preamble" "aof-use-rdb-preamble\nno" "AOF rewrites use the module callbacks"
 
   rcall_assert "R.SETINTARRAY test_aof_r32 1 2 5 100 65536" "OK" "Seed a 32 bit bitmap"
   rcall_assert "R64.SETINTARRAY test_aof_r64 1 2 5 100 65536 18446744073709551615" "OK" "Seed a 64 bit bitmap up to the 64 bit maximum"
@@ -36,6 +51,11 @@ function seed_bitmaps() {
   rcall_assert "R64.SETINTARRAY test_aof_r64_big$values" "OK" "Seed a 64 bit bitmap larger than one rewrite chunk"
   rcall_assert "R64.BITCOUNT test_aof_r64_big" "$BIG_COUNT" "Large 64 bit bitmap has every value before the rewrite"
 
+  rcall_assert "R.SETINTARRAY test_aof_r32_big$values" "OK" "Seed a 32 bit bitmap larger than one rewrite chunk"
+  rcall_assert "R.BITCOUNT test_aof_r32_big" "$BIG_COUNT" "Large 32 bit bitmap has every value before the rewrite"
+
+  rcall_assert "DBSIZE" "6" "Only the seeded keys exist before the rewrite"
+
   rewrite_aof
 }
 
@@ -48,7 +68,7 @@ function rewrite_aof() {
   local info=""
   while true; do
     info=$(./deps/redis/src/redis-cli -p "$REDIS_PORT" INFO persistence | tr -d '\r')
-    if [ "$(echo "$info" | grep -c '^aof_rewrite_in_progress:0')" == "1" ]; then
+    if echo "$info" | grep -q '^aof_rewrite_in_progress:0'; then
       break
     fi
     tries=$((tries + 1))
@@ -70,6 +90,20 @@ function rewrite_aof() {
   fi
 
   rcall_assert "PING" "PONG" "Server is responsive after the rewrite"
+
+  # The chunked emission is what turns a huge bitmap into a handful of commands;
+  # assert it rather than trusting that BIG_COUNT still exceeds the chunk size.
+  local aof
+  aof=$(cat_rewritten_aof | tr -d '\r')
+  if ! echo "$aof" | grep -q "R64.APPENDINTARRAY"; then
+    echo "The rewritten AOF has no R64.APPENDINTARRAY: the 64 bit bitmap was not chunked" >&2
+    return 1
+  fi
+  if ! echo "$aof" | grep -q "R.APPENDINTARRAY"; then
+    echo "The rewritten AOF has no R.APPENDINTARRAY: the 32 bit bitmap was not chunked" >&2
+    return 1
+  fi
+  echo -e "\x1b[32m✓\x1b[0m Both bitmaps were emitted in chunks"
 }
 
 function verify_bitmaps() {
@@ -93,6 +127,13 @@ function verify_bitmaps() {
   rcall_assert "R64.GETBIT test_aof_r64_big 0" "1" "Chunked 64 bit bitmap keeps its first value"
   rcall_assert "R64.GETBIT test_aof_r64_big $(((BIG_COUNT - 1) * 1000))" "1" "Chunked 64 bit bitmap keeps its last value"
   rcall_assert "R64.GETBIT test_aof_r64_big 1" "0" "Chunked 64 bit bitmap gained no extra values"
+
+  rcall_assert "R.BITCOUNT test_aof_r32_big" "$BIG_COUNT" "Chunked 32 bit bitmap keeps every value"
+  rcall_assert "R.GETBIT test_aof_r32_big 0" "1" "Chunked 32 bit bitmap keeps its first value"
+  rcall_assert "R.GETBIT test_aof_r32_big $(((BIG_COUNT - 1) * 1000))" "1" "Chunked 32 bit bitmap keeps its last value"
+  rcall_assert "R.GETBIT test_aof_r32_big 1" "0" "Chunked 32 bit bitmap gained no extra values"
+
+  rcall_assert "DBSIZE" "6" "The rewrite restored exactly the seeded keys"
 }
 
 case "${1:-}" in

--- a/tests/integration_5.sh
+++ b/tests/integration_5.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -eu
+
+. "$(dirname "$0")/helper.sh"
+
+# Exercises the module's aof_rewrite callbacks. The AOF command log alone does
+# not reach them: they only run when the server rewrites the AOF without an RDB
+# preamble, so the caller must start Redis with --aof-use-rdb-preamble no.
+#
+# Run as `integration_5.sh seed` before a restart and `integration_5.sh verify`
+# after it.
+
+BIG_COUNT=1200
+
+function seed_bitmaps() {
+  print_test_header "test_aof_rewrite_seed"
+
+  rcall_assert "R.SETINTARRAY test_aof_r32 1 2 5 100 65536" "OK" "Seed a 32 bit bitmap"
+  rcall_assert "R64.SETINTARRAY test_aof_r64 1 2 5 100 65536 18446744073709551615" "OK" "Seed a 64 bit bitmap up to the 64 bit maximum"
+
+  # Emptied bitmaps: the key still exists and must survive the rewrite.
+  rcall_assert "R.SETINTARRAY test_aof_r32_empty 7" "OK" "Seed a 32 bit bitmap to empty out"
+  rcall_assert "R.SETBIT test_aof_r32_empty 7 0" "1" "Clear the only bit of the 32 bit bitmap"
+  rcall_assert "R.BITCOUNT test_aof_r32_empty" "0" "32 bit bitmap is empty before the rewrite"
+
+  rcall_assert "R64.SETINTARRAY test_aof_r64_empty 7" "OK" "Seed a 64 bit bitmap to empty out"
+  rcall_assert "R64.SETBIT test_aof_r64_empty 7 0" "1" "Clear the only bit of the 64 bit bitmap"
+  rcall_assert "R64.BITCOUNT test_aof_r64_empty" "0" "64 bit bitmap is empty before the rewrite"
+
+  # More values than fit a single emitted command, to cover chunked rewrites.
+  local values=""
+  for ((i = 0; i < BIG_COUNT; i++)); do
+    values="$values $((i * 1000))"
+  done
+  rcall_assert "R64.SETINTARRAY test_aof_r64_big$values" "OK" "Seed a 64 bit bitmap larger than one rewrite chunk"
+  rcall_assert "R64.BITCOUNT test_aof_r64_big" "$BIG_COUNT" "Large 64 bit bitmap has every value before the rewrite"
+
+  rewrite_aof
+}
+
+function rewrite_aof() {
+  print_test_header "test_aof_rewrite_run"
+
+  rcall_assert "BGREWRITEAOF" "Background append only file rewriting started" "Start the AOF rewrite"
+
+  local tries=0
+  while [ "$(./deps/redis/src/redis-cli -p "$REDIS_PORT" INFO persistence | grep -c '^aof_rewrite_in_progress:0')" != "1" ]; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge 300 ]; then
+      echo "AOF rewrite did not finish" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  rcall_assert "PING" "PONG" "Server is responsive after the rewrite"
+}
+
+function verify_bitmaps() {
+  print_test_header "test_aof_rewrite_verify"
+
+  rcall_assert "R.BITCOUNT test_aof_r32" "5" "32 bit bitmap keeps its cardinality"
+  rcall_assert "R.GETINTARRAY test_aof_r32" "1\n2\n5\n100\n65536" "32 bit bitmap keeps its values"
+
+  rcall_assert "R64.BITCOUNT test_aof_r64" "6" "64 bit bitmap keeps its cardinality"
+  rcall_assert "R64.GETINTARRAY test_aof_r64" "1\n2\n5\n100\n65536\n18446744073709551615" "64 bit bitmap keeps its values, including the 64 bit maximum"
+
+  rcall_assert "EXISTS test_aof_r32_empty" "1" "Empty 32 bit bitmap survives the rewrite"
+  rcall_assert "R.BITCOUNT test_aof_r32_empty" "0" "Empty 32 bit bitmap is still empty"
+  rcall_assert "R.GETBIT test_aof_r32_empty 7" "0" "Empty 32 bit bitmap did not regain its cleared bit"
+
+  rcall_assert "EXISTS test_aof_r64_empty" "1" "Empty 64 bit bitmap survives the rewrite"
+  rcall_assert "R64.BITCOUNT test_aof_r64_empty" "0" "Empty 64 bit bitmap is still empty"
+  rcall_assert "R64.GETBIT test_aof_r64_empty 7" "0" "Empty 64 bit bitmap did not regain its cleared bit"
+
+  rcall_assert "R64.BITCOUNT test_aof_r64_big" "$BIG_COUNT" "Chunked 64 bit bitmap keeps every value"
+  rcall_assert "R64.GETBIT test_aof_r64_big 0" "1" "Chunked 64 bit bitmap keeps its first value"
+  rcall_assert "R64.GETBIT test_aof_r64_big $(((BIG_COUNT - 1) * 1000))" "1" "Chunked 64 bit bitmap keeps its last value"
+  rcall_assert "R64.GETBIT test_aof_r64_big 1" "0" "Chunked 64 bit bitmap gained no extra values"
+}
+
+case "${1:-}" in
+  seed)
+    seed_bitmaps
+    ;;
+  verify)
+    verify_bitmaps
+    ;;
+  *)
+    echo "usage: $0 {seed|verify}" >&2
+    exit 1
+    ;;
+esac

--- a/tests/integration_5.sh
+++ b/tests/integration_5.sh
@@ -45,7 +45,12 @@ function rewrite_aof() {
   rcall_assert "BGREWRITEAOF" "Background append only file rewriting started" "Start the AOF rewrite"
 
   local tries=0
-  while [ "$(./deps/redis/src/redis-cli -p "$REDIS_PORT" INFO persistence | grep -c '^aof_rewrite_in_progress:0')" != "1" ]; do
+  local info=""
+  while true; do
+    info=$(./deps/redis/src/redis-cli -p "$REDIS_PORT" INFO persistence | tr -d '\r')
+    if [ "$(echo "$info" | grep -c '^aof_rewrite_in_progress:0')" == "1" ]; then
+      break
+    fi
     tries=$((tries + 1))
     if [ "$tries" -ge 300 ]; then
       echo "AOF rewrite did not finish" >&2
@@ -53,6 +58,16 @@ function rewrite_aof() {
     fi
     sleep 0.1
   done
+
+  # Reaching progress zero is not enough: a failed rewrite leaves the previous
+  # AOF in place, so the reload below would replay the seed commands and pass
+  # without ever loading the module's rewrite output.
+  local status
+  status=$(echo "$info" | grep '^aof_last_bgrewrite_status:' | cut -d: -f2)
+  if [ "$status" != "ok" ]; then
+    echo "AOF rewrite failed: $status" >&2
+    return 1
+  fi
 
   rcall_assert "PING" "PONG" "Server is responsive after the rewrite"
 }

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -34,6 +34,9 @@ MANIFEST_VERSION = 1
 # replacing the removed BITMAP CONVERT command.
 EMPTY_NATIVE_BITMAP_PAYLOAD = bytes.fromhex("21000800000000000000000f000000000000000000")
 
+# Scratch key used by the preflight seed probe, removed as soon as it is checked.
+SEED_PROBE_KEY = b"__bitmap_migrate_seed_probe__"
+
 
 class MigrateError(RuntimeError):
     pass
@@ -393,6 +396,37 @@ class BitmapMigrator:
             raise MigrateError("target cluster mode is enabled; this tool does not migrate cluster targets unless --allow-cluster is set")
         if self.args.allow_cluster:
             raise MigrateError("cluster migration is not implemented yet; rerun against standalone masters or omit --allow-cluster")
+        if self.args.apply:
+            self.verify_native_bitmap_seed()
+
+    def verify_native_bitmap_seed(self) -> None:
+        """Check that the target still accepts the empty native bitmap seed.
+
+        Every key is built on top of a RESTORE of EMPTY_NATIVE_BITMAP_PAYLOAD, a
+        constant that encodes the target's RDB type id for native bitmaps and its
+        payload layout. When the native server changes either, every key fails
+        with an opaque "Bad data format", so probe once up front and say what
+        actually needs fixing.
+        """
+        try:
+            self.target.execute(["RESTORE", SEED_PROBE_KEY, "0", EMPTY_NATIVE_BITMAP_PAYLOAD, "REPLACE"])
+        except RedisError as exc:
+            raise MigrateError(
+                f"target rejected the empty native bitmap seed payload ({exc}); "
+                "the native bitmap RDB encoding has changed, so "
+                "EMPTY_NATIVE_BITMAP_PAYLOAD must be regenerated from a DUMP of "
+                "an empty native bitmap on the target"
+            ) from exc
+        try:
+            kind = decode_text(self.target.execute(["TYPE", SEED_PROBE_KEY]))
+            if kind != "bitmap":
+                raise MigrateError(
+                    f"empty native bitmap seed payload restored as type {kind!r} "
+                    "instead of 'bitmap'; EMPTY_NATIVE_BITMAP_PAYLOAD must be "
+                    "regenerated from a DUMP of an empty native bitmap on the target"
+                )
+        finally:
+            self.target.execute(["DEL", SEED_PROBE_KEY])
 
     def cluster_enabled(self, client: RedisClient) -> bool:
         try:

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -26,12 +26,13 @@ from typing import Any, Iterator, Optional
 NATIVE_V1_MAX_BIT = 4294967295
 MANIFEST_VERSION = 1
 
-# DUMP/RESTORE payload for an empty native bitmap: RDB_TYPE_BITMAP (29),
-# logical byte length 0, an empty raw string, RDB version 15, and an all-zero
-# checksum footer (zero means "no checksum" and RESTORE accepts it). Restoring
-# this constant creates a native bitmap on the target regardless of its
-# bitmap-default-roaring setting, replacing the removed BITMAP CONVERT command.
-EMPTY_NATIVE_BITMAP_PAYLOAD = bytes.fromhex("1d00000f000000000000000000")
+# DUMP/RESTORE payload for an empty native bitmap: RDB_TYPE_BITMAP (33),
+# logical byte length 0, the 8-byte CRoaring64 portable blob of an empty
+# bitmap, RDB version 15, and an all-zero checksum footer (zero means "no
+# checksum" and RESTORE accepts it). Restoring this constant creates a native
+# bitmap on the target regardless of its bitmap-default-roaring setting,
+# replacing the removed BITMAP CONVERT command.
+EMPTY_NATIVE_BITMAP_PAYLOAD = bytes.fromhex("21000800000000000000000f000000000000000000")
 
 
 class MigrateError(RuntimeError):

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -382,8 +382,10 @@ class BitmapMigrator:
         self.failed_entries_this_run: set[str] = set()
 
     def run(self) -> int:
-        self.manifest.save()
+        # Preflight first: a manifest written before it aborts would make the
+        # rerun the error message asks for fail with "manifest already exists".
         self.preflight()
+        self.manifest.save()
         dbs = self.discover_dbs()
         for db in dbs:
             self.migrate_db(db)
@@ -401,10 +403,13 @@ class BitmapMigrator:
             raise MigrateError("target cluster mode is enabled; this tool does not migrate cluster targets unless --allow-cluster is set")
         if self.args.allow_cluster:
             raise MigrateError("cluster migration is not implemented yet; rerun against standalone masters or omit --allow-cluster")
+        # Only --apply, so a dry run still leaves the target untouched. A dry run
+        # therefore cannot report a stale seed payload; see the migration contract.
         if self.args.apply:
-            self.verify_native_bitmap_seed()
+            for db in self.discover_dbs():
+                self.verify_native_bitmap_seed(db)
 
-    def verify_native_bitmap_seed(self) -> None:
+    def verify_native_bitmap_seed(self, db: int) -> None:
         """Check that the target still accepts the empty native bitmap seed.
 
         Every key is built on top of a RESTORE of EMPTY_NATIVE_BITMAP_PAYLOAD, a
@@ -412,23 +417,40 @@ class BitmapMigrator:
         payload layout. When the native server changes either, every key fails
         with an opaque "Bad data format", so probe once up front and say what
         actually needs fixing.
+
+        The probe runs in the database the migration will write to, so it never
+        touches a database the operator did not put in scope.
         """
-        if parse_uint(self.target.execute(["EXISTS", SEED_PROBE_KEY]), "EXISTS probe"):
+        target = self.target.with_db(db)
+        try:
+            exists = parse_uint(target.execute(["EXISTS", SEED_PROBE_KEY]), "EXISTS probe")
+        except RedisError as exc:
+            raise MigrateError(
+                f"target rejected the preflight probe in db {db}: {exc}"
+            ) from exc
+        if exists:
             raise MigrateError(
                 f"preflight probe key {key_to_text(SEED_PROBE_KEY)} already exists on "
-                "the target; remove it and rerun so preflight cannot touch real data"
+                f"the target in db {db}; delete it and rerun (add --resume if a "
+                "manifest was already written) so preflight cannot touch real data"
             )
 
         # No REPLACE: the key was just shown to be absent, so a BUSYKEY here means
         # something else created it and the probe must not clobber it.
         try:
-            self.target.execute(["RESTORE", SEED_PROBE_KEY, "0", EMPTY_NATIVE_BITMAP_PAYLOAD])
+            target.execute(["RESTORE", SEED_PROBE_KEY, "0", EMPTY_NATIVE_BITMAP_PAYLOAD])
         except RedisError as exc:
             if not is_bad_payload_error(exc):
                 # Permissions, a read-only replica, a racing writer: regenerating the
                 # payload would not help, so report what the target actually said.
                 raise MigrateError(
-                    f"target rejected the empty native bitmap seed probe: {exc}"
+                    f"target rejected the empty native bitmap seed probe in db {db}: {exc}"
+                ) from exc
+            if not self.target_has_native_bitmaps():
+                raise MigrateError(
+                    f"target rejected the empty native bitmap seed payload ({exc}) and "
+                    "does not look like a Redis build with a native bitmap type; check "
+                    "that --target-host/--target-port point at the right server"
                 ) from exc
             raise MigrateError(
                 f"target rejected the empty native bitmap seed payload ({exc}); "
@@ -439,7 +461,13 @@ class BitmapMigrator:
 
         # The probe key is ours from here: it did not exist and this RESTORE created it.
         try:
-            kind = decode_text(self.target.execute(["TYPE", SEED_PROBE_KEY]))
+            kind = decode_text(target.execute(["TYPE", SEED_PROBE_KEY]))
+            if kind == "none":
+                raise MigrateError(
+                    f"preflight probe key {key_to_text(SEED_PROBE_KEY)} disappeared in "
+                    f"db {db} before it could be checked; rerun against a target that is "
+                    "not evicting or expiring keys from under the migration"
+                )
             if kind != "bitmap":
                 raise MigrateError(
                     f"empty native bitmap seed payload restored as type {kind!r} "
@@ -447,7 +475,19 @@ class BitmapMigrator:
                     "regenerated from a DUMP of an empty native bitmap on the target"
                 )
         finally:
-            self.target.execute(["DEL", SEED_PROBE_KEY])
+            try:
+                target.execute(["DEL", SEED_PROBE_KEY])
+            except RedisError:
+                # Never let cleanup replace the diagnosis the probe just produced.
+                pass
+
+    def target_has_native_bitmaps(self) -> bool:
+        """Best-effort check that the target is a build with a native bitmap type."""
+        try:
+            reply = self.target.execute(["CONFIG", "GET", "bitmap-default-roaring"])
+        except RedisError:
+            return True
+        return bool(reply)
 
     def cluster_enabled(self, client: RedisClient) -> bool:
         try:

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -96,6 +96,11 @@ def is_wrongtype_error(exc: RedisError) -> bool:
     return "WRONGTYPE" in message or "OPERATION AGAINST A KEY" in message
 
 
+def is_bad_payload_error(exc: RedisError) -> bool:
+    message = str(exc).upper()
+    return "BAD DATA FORMAT" in message or "PAYLOAD VERSION OR CHECKSUM" in message
+
+
 def is_unknown_command_error(exc: RedisError) -> bool:
     message = str(exc).upper()
     return "UNKNOWN COMMAND" in message or "ERR UNKNOWN" in message
@@ -408,15 +413,31 @@ class BitmapMigrator:
         with an opaque "Bad data format", so probe once up front and say what
         actually needs fixing.
         """
+        if parse_uint(self.target.execute(["EXISTS", SEED_PROBE_KEY]), "EXISTS probe"):
+            raise MigrateError(
+                f"preflight probe key {key_to_text(SEED_PROBE_KEY)} already exists on "
+                "the target; remove it and rerun so preflight cannot touch real data"
+            )
+
+        # No REPLACE: the key was just shown to be absent, so a BUSYKEY here means
+        # something else created it and the probe must not clobber it.
         try:
-            self.target.execute(["RESTORE", SEED_PROBE_KEY, "0", EMPTY_NATIVE_BITMAP_PAYLOAD, "REPLACE"])
+            self.target.execute(["RESTORE", SEED_PROBE_KEY, "0", EMPTY_NATIVE_BITMAP_PAYLOAD])
         except RedisError as exc:
+            if not is_bad_payload_error(exc):
+                # Permissions, a read-only replica, a racing writer: regenerating the
+                # payload would not help, so report what the target actually said.
+                raise MigrateError(
+                    f"target rejected the empty native bitmap seed probe: {exc}"
+                ) from exc
             raise MigrateError(
                 f"target rejected the empty native bitmap seed payload ({exc}); "
                 "the native bitmap RDB encoding has changed, so "
                 "EMPTY_NATIVE_BITMAP_PAYLOAD must be regenerated from a DUMP of "
                 "an empty native bitmap on the target"
             ) from exc
+
+        # The probe key is ours from here: it did not exist and this RESTORE created it.
         try:
             kind = decode_text(self.target.execute(["TYPE", SEED_PROBE_KEY]))
             if kind != "bitmap":

--- a/tools/redis-bitmap-migrate.py
+++ b/tools/redis-bitmap-migrate.py
@@ -460,6 +460,13 @@ class BitmapMigrator:
             ) from exc
 
         # The probe key is ours from here: it did not exist and this RESTORE created it.
+        def delete_probe() -> Optional[RedisError]:
+            try:
+                target.execute(["DEL", SEED_PROBE_KEY])
+            except RedisError as exc:
+                return exc
+            return None
+
         try:
             kind = decode_text(target.execute(["TYPE", SEED_PROBE_KEY]))
             if kind == "none":
@@ -474,12 +481,20 @@ class BitmapMigrator:
                     "instead of 'bitmap'; EMPTY_NATIVE_BITMAP_PAYLOAD must be "
                     "regenerated from a DUMP of an empty native bitmap on the target"
                 )
-        finally:
-            try:
-                target.execute(["DEL", SEED_PROBE_KEY])
-            except RedisError:
-                # Never let cleanup replace the diagnosis the probe just produced.
-                pass
+        except BaseException:
+            # A diagnosis is already on its way up; cleanup must not replace it.
+            delete_probe()
+            raise
+
+        # On the success path a failed cleanup is not cosmetic: the probe key is
+        # reserved, so leaving it behind aborts every later run.
+        cleanup_error = delete_probe()
+        if cleanup_error is not None:
+            raise MigrateError(
+                f"preflight could not delete its probe key "
+                f"{key_to_text(SEED_PROBE_KEY)} in db {db} ({cleanup_error}); "
+                "delete it before rerunning"
+            ) from cleanup_error
 
     def target_has_native_bitmaps(self) -> bool:
         """Best-effort check that the target is a build with a native bitmap type."""


### PR DESCRIPTION
Fixes #151.

Started from the `SETBIT` bug in #151 and, while getting CI green enough to prove the fix, found three more problems.

## 1. `SETBIT` ignores `value` on a missing key — #151

`R.SETBIT` / `R64.SETBIT` built the new bitmap straight from the offset when the key did not exist, so clearing a bit on a fresh key set it instead:

```
R.SETBIT k 5 0   -> 0
R.GETBIT k 5     -> 1   # expected 0
R.BITCOUNT k     -> 1   # expected 0
```

The offset is now included only when the bit is being set. The reply and the fact that the key is created are unchanged.

Originally reported and patched by @fjmaco in #150; this carries the same fix.

## 2. AOF rewrite loses and corrupts bitmaps

Both module types implement `aof_rewrite` and both got it wrong. The callbacks only run when the AOF is rewritten without an RDB preamble, and nothing exercised that path.

`Bitmap64AofRewrite` emitted:

```c
RedisModule_EmitAOF(aof, "R64.SETINTARRAY", "sl", key, values, cardinality);
```

`"l"` consumes a single `long long`, so the value array's *address* was written into the AOF as one decimal number and `cardinality` was dropped:

```
before rewrite:  {1, 2, 5, 100, 65536}
AOF contains:    R64.SETINTARRAY b64 140621205707864
after reload:    {140621205707864}
```

Both widths now emit values as a vector of strings in chunks of 512 — `SETINTARRAY` for the first chunk, `APPENDINTARRAY` for the rest. Previously the 32-bit path emitted one command per bit, so a 10^8-bit bitmap produced 10^8 AOF commands.

Separately, both callbacks emitted nothing for a zero-cardinality bitmap, so a key holding an empty bitmap disappeared across a rewrite even though it still existed. Both now emit a single `SETBIT key 0 0`, which recreates the key holding an empty bitmap thanks to the fix in section 1 — one command, so a truncated AOF cannot resurrect bit 0.

Adds `tests/integration_5.sh` with a new `integration_5` step that seeds, rewrites and reloads.

## 3. The migrator job had been red on `master` for a month

`Validate bitmap migrator` failed on `master` on every scheduled run for at least 30 nights, with all six `RealRedisRoaringMigrationTests` failing on `ERR Bad data format`.

The migrator seeds every target key by restoring a hardcoded empty-bitmap payload that encoded RDB type 29. The native fork has since moved `RDB_TYPE_BITMAP` to 33 (29 is now `RDB_TYPE_HASH_TMPL_LP`) and changed the body to a logical byte length plus a CRoaring64 portable blob. The constant is regenerated from a `DUMP` of a real empty native bitmap.

The job still tracks `aviggiano/redis@unstable`, deliberately: that is where Redis core goes live, so this job is the early warning that the encoding moved. What made this breakage expensive was not the moving ref but the opaque per-key error. An `--apply` run now probes the constant once per database during preflight and names the remedy, so the next drift reads as "regenerate the payload" instead of six identical `Bad data format` failures.

## 4. Build warnings

The statistics formatters passed `uint64_t` to `%llu`, which is `unsigned long` on LP64 — 28 `-Wformat` warnings on every build. Now `PRIu64`. Also `ERRORMSG_RANGE_LIMIT` fed an `int` to `%llu`, which `-Wformat` could not see because `ReplyWithErrorFmt` carries no format attribute.

## Review

Three independent reviews were run over the branch, plus two rounds of Codex. Beyond the above they found, and this PR fixes:

- **The new AOF test could pass without testing anything.** Nothing asserted the server actually had `aof-use-rdb-preamble no`, and `start_redis` silently dropped unrecognised flags — so a typo in the flag would have quietly downgraded the test to a duplicate of `integration_2`, green forever. Re-running the cycle with the flag omitted passed every assertion while the callbacks never ran. It now asserts the setting, rejects unknown options, and asserts the rewritten AOF really contains `APPENDINTARRAY` rather than assuming the seed exceeds the chunk size.
- **The migrator's preflight probe ran against db 0** whatever `--db` asked for, writing and deleting a key in a database the operator never scoped.
- **"Remove it and rerun" did not work** — the manifest was written before preflight, so the rerun died on "manifest already exists".
- **A failed probe cleanup passed silently**, stranding the reserved key and wedging every later run.
- Plus: the BGREWRITEAOF valgrind child polluting the parent's log and gating the rewrite with its exit code, an unbounded readiness loop that could hang a job until the six-hour timeout, `appendonly.aof` left behind on the Redis 6.2 layout, and migrator tests that discarded the tool's stderr and so reported failures as a bare `1 != 0`.

## Verification

- `./test.sh`: 261 unit tests, all five integration groups, 0 failures.
- Under valgrind: `integration_1`, `integration_3` and `integration_5` all report 0 bytes definitely and indirectly lost.
- 26 migrator tests pass against a locally built native fork.
- Each fix was confirmed to fail on the code before it — the AOF test with the key missing and cardinality 1 instead of 1200, the db-scoping test with no `SELECT` before the probe, the cleanup test passing preflight and dying later on `FAILED db=0 key=foo`.
- Build is warning-free.