### PR TITLE
Fix unbounded out-of-bounds read in BitmapRdbLoad (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
         sudo apt-get update
         sudo apt-get install -y gcc-multilib g++-multilib libc6-dev-i386
+    - name: Generate CRoaring headers
+      run: ./deps/CRoaring/amalgamation.sh src
     - name: Build 32-bit unit and module targets
       run: |
         cmake -S . -B build-32 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,38 @@ jobs:
     - name: Test
       run: ./test.sh
 
+  test_32bit:
+    if: github.event_name != 'schedule'
+    name: Test 32-bit RDB bounds validation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install 32-bit toolchain
+      run: |
+        # These preinstalled repositories intermittently publish invalid
+        # metadata; none of the packages below come from them.
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib g++-multilib libc6-dev-i386
+    - name: Build 32-bit unit and module targets
+      run: |
+        cmake -S . -B build-32 \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS=-m32 \
+          -DCMAKE_CXX_FLAGS=-m32 \
+          -DCMAKE_EXE_LINKER_FLAGS=-m32 \
+          -DCMAKE_SHARED_LINKER_FLAGS=-m32 \
+          -DROARING_DISABLE_X64=ON
+        cmake --build build-32 --target unit redis-roaring -- -j"$(nproc)"
+    - name: Run 32-bit regression tests
+      run: |
+        file build-32/unit | grep 'ELF 32-bit'
+        file build-32/libredis-roaring.so | grep 'ELF 32-bit'
+        ./build-32/unit
+
   coverage:
     if: github.event_name != 'schedule'
     name: Generate and upload coverage

--- a/src/bitmap_rdb.h
+++ b/src/bitmap_rdb.h
@@ -1,0 +1,32 @@
+#ifndef REDIS_ROARING_BITMAP_RDB_H
+#define REDIS_ROARING_BITMAP_RDB_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+static inline bool BitmapSerializedArrayFits(const char* serialized_bitmap, size_t size) {
+  /* CRoaring's native format uses tag 1 followed by a native-endian uint32_t
+   * cardinality and that many uint32_t values. Its pinned safe deserializer
+   * computes the required size with size_t arithmetic that can wrap on 32-bit
+   * builds, so validate this format with subtraction before calling it. */
+  const uint8_t array_uint32_tag = 1;
+  const size_t header_size = 1 + sizeof(uint32_t);
+
+  if (serialized_bitmap == NULL || size == 0) {
+    return false;
+  }
+  if ((uint8_t) serialized_bitmap[0] != array_uint32_tag) {
+    return true; /* Let CRoaring validate its other serialization formats. */
+  }
+  if (size < header_size) {
+    return false;
+  }
+
+  uint32_t cardinality;
+  memcpy(&cardinality, serialized_bitmap + 1, sizeof(cardinality));
+  return (size_t) cardinality <= (size - header_size) / sizeof(uint32_t);
+}
+
+#endif

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "parse.h"
 #include "bitop_keys.h"
+#include "bitmap_rdb.h"
 #include "cmd_info/command_info.h"
 
 RedisModuleType* BitmapType = NULL;
@@ -114,8 +115,19 @@ void* BitmapRdbLoad(RedisModuleIO* rdb, int encver) {
     RedisModule_LogIOError(rdb, "warning", "Can't load data with version %d", encver);
     return NULL;
   }
-  size_t size;
+  size_t size = 0;
   char* serialized_bitmap = RedisModule_LoadStringBuffer(rdb, &size);
+  if (serialized_bitmap == NULL || RedisModule_IsIOError(rdb)) {
+    if (serialized_bitmap != NULL) {
+      rm_free(serialized_bitmap);
+    }
+    return NULL;
+  }
+  if (!BitmapSerializedArrayFits(serialized_bitmap, size)) {
+    rm_free(serialized_bitmap);
+    RedisModule_LogIOError(rdb, "warning", "Failed to deserialize a corrupt or truncated bitmap");
+    return NULL;
+  }
   /* Deserialize with the size-checked variant: the buffer comes from
    * RESTORE/RDB and is attacker-controlled. The unsafe roaring_bitmap_deserialize
    * trusts the serialized cardinality header and reads that many elements past

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -123,10 +123,23 @@ void* BitmapRdbLoad(RedisModuleIO* rdb, int encver) {
    * safe variant bounds every read by the loaded size and returns NULL on a
    * truncated or corrupt payload (mirrors Bitmap64RdbLoad). */
   Bitmap* bitmap = roaring_bitmap_deserialize_safe(serialized_bitmap, size);
+  rm_free(serialized_bitmap);
   if (bitmap == NULL) {
     RedisModule_LogIOError(rdb, "warning", "Failed to deserialize a corrupt or truncated bitmap");
+    return NULL;
   }
-  rm_free(serialized_bitmap);
+  /* The size-checked deserialize guarantees no read past the buffer, but it does
+   * not verify that the resulting bitmap is internally consistent. A payload
+   * that stays within size can still describe a malformed bitmap (e.g. an
+   * unsorted or oversized container) that corrupts memory when later operated
+   * on. CRoaring documents that untrusted input must be validated before use, so
+   * reject anything that fails the consistency check. */
+  const char* reason = NULL;
+  if (!roaring_bitmap_internal_validate(bitmap, &reason)) {
+    RedisModule_LogIOError(rdb, "warning", "Rejected an inconsistent bitmap: %s", reason ? reason : "unknown");
+    bitmap_free(bitmap);
+    return NULL;
+  }
   return bitmap;
 }
 

--- a/src/r_32.c
+++ b/src/r_32.c
@@ -116,7 +116,16 @@ void* BitmapRdbLoad(RedisModuleIO* rdb, int encver) {
   }
   size_t size;
   char* serialized_bitmap = RedisModule_LoadStringBuffer(rdb, &size);
-  Bitmap* bitmap = roaring_bitmap_deserialize(serialized_bitmap);
+  /* Deserialize with the size-checked variant: the buffer comes from
+   * RESTORE/RDB and is attacker-controlled. The unsafe roaring_bitmap_deserialize
+   * trusts the serialized cardinality header and reads that many elements past
+   * the buffer, so a crafted payload triggers a large out-of-bounds read. The
+   * safe variant bounds every read by the loaded size and returns NULL on a
+   * truncated or corrupt payload (mirrors Bitmap64RdbLoad). */
+  Bitmap* bitmap = roaring_bitmap_deserialize_safe(serialized_bitmap, size);
+  if (bitmap == NULL) {
+    RedisModule_LogIOError(rdb, "warning", "Failed to deserialize a corrupt or truncated bitmap");
+  }
   rm_free(serialized_bitmap);
   return bitmap;
 }

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -120,10 +120,21 @@ void* Bitmap64RdbLoad(RedisModuleIO* rdb, int encver) {
    * so it is bounded by the loaded size and returns NULL on a truncated or
    * corrupt payload rather than reading past the buffer. */
   Bitmap64* bitmap = roaring64_bitmap_portable_deserialize_safe(serialized_bitmap, size);
+  rm_free(serialized_bitmap);
   if (bitmap == NULL) {
     RedisModule_LogIOError(rdb, "warning", "Failed to deserialize a corrupt or truncated bitmap");
+    return NULL;
   }
-  rm_free(serialized_bitmap);
+  /* Size-checked deserialize does not verify internal consistency: a payload
+   * that stays within size can still describe a malformed bitmap that corrupts
+   * memory when later operated on. CRoaring documents that untrusted input must
+   * be validated before use, so reject anything that fails the check. */
+  const char* reason = NULL;
+  if (!roaring64_bitmap_internal_validate(bitmap, &reason)) {
+    RedisModule_LogIOError(rdb, "warning", "Rejected an inconsistent bitmap: %s", reason ? reason : "unknown");
+    bitmap64_free(bitmap);
+    return NULL;
+  }
   return bitmap;
 }
 

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -116,7 +116,13 @@ void* Bitmap64RdbLoad(RedisModuleIO* rdb, int encver) {
   }
   size_t size;
   char* serialized_bitmap = RedisModule_LoadStringBuffer(rdb, &size);
+  /* Size-checked deserialize: the buffer is attacker-controlled (RESTORE/RDB),
+   * so it is bounded by the loaded size and returns NULL on a truncated or
+   * corrupt payload rather than reading past the buffer. */
   Bitmap64* bitmap = roaring64_bitmap_portable_deserialize_safe(serialized_bitmap, size);
+  if (bitmap == NULL) {
+    RedisModule_LogIOError(rdb, "warning", "Failed to deserialize a corrupt or truncated bitmap");
+  }
   rm_free(serialized_bitmap);
   return bitmap;
 }

--- a/src/r_64.c
+++ b/src/r_64.c
@@ -114,8 +114,14 @@ void* Bitmap64RdbLoad(RedisModuleIO* rdb, int encver) {
     RedisModule_LogIOError(rdb, "warning", "Can't load data with version %d", encver);
     return NULL;
   }
-  size_t size;
+  size_t size = 0;
   char* serialized_bitmap = RedisModule_LoadStringBuffer(rdb, &size);
+  if (serialized_bitmap == NULL || RedisModule_IsIOError(rdb)) {
+    if (serialized_bitmap != NULL) {
+      rm_free(serialized_bitmap);
+    }
+    return NULL;
+  }
   /* Size-checked deserialize: the buffer is attacker-controlled (RESTORE/RDB),
    * so it is bounded by the loaded size and returns NULL on a truncated or
    * corrupt payload rather than reading past the buffer. */

--- a/src/redis-roaring.c
+++ b/src/redis-roaring.c
@@ -69,6 +69,11 @@ int RedisModule_OnLoad(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) 
     return REDISMODULE_ERR;
   }
 
+  /* Redis normally aborts an RDB load when a module Load* call sees malformed
+   * input. Opt in to recoverable I/O errors so our loaders can reject corrupt
+   * RESTORE/RDB payloads without taking down the server. */
+  RedisModule_SetModuleOptions(ctx, REDISMODULE_OPTIONS_HANDLE_IO_ERRORS);
+
   RedisModule_Log(ctx,
     "notice",
     "RedisRoaring version %d",

--- a/test.sh
+++ b/test.sh
@@ -115,6 +115,20 @@ function integration_5() {
   echo "All integration (5) tests passed"
 }
 
+function integration_6() {
+  stop_redis
+  rm dump.rdb 2>/dev/null || true
+  if [[ "${USE_VALGRIND:-1}" == "1" ]]; then
+    start_redis --valgrind
+  else
+    start_redis
+  fi
+  REDIS_PORT="$REDIS_PORT" python3 ./tests/integration_6.py
+  stop_redis
+  rm dump.rdb 2>/dev/null || true
+  echo "All integration (6) tests passed"
+}
+
 setup
 unit
 integration_1
@@ -122,6 +136,7 @@ integration_2
 integration_3
 integration_4
 integration_5
+integration_6
 
 echo ""
 echo "************************"

--- a/tests/integration_6.py
+++ b/tests/integration_6.py
@@ -155,6 +155,40 @@ def craft_oob_payload(payload, fake_cardinality):
     return repatch_crc(bytes(tampered))
 
 
+# A native CONTAINER-tagged (0x02) blob whose portable array container holds two
+# UNSORTED uint16 values. roaring_bitmap_deserialize_safe reads it fully in-bounds
+# -- the size check alone accepts it -- but the container violates the sorted
+# invariant, so roaring_bitmap_internal_validate rejects it. This is the case the
+# CRoaring maintainer raised on PR #154: a size-checked deserialize is not enough
+# on untrusted input; the structure must also be validated. Generated against the
+# pinned CRoaring, where deserialize_safe returns non-NULL and internal_validate
+# reports "array elements not strictly increasing". If the vendored CRoaring's
+# portable format ever changes, regenerate this blob.
+_MALFORMED_UNSORTED_BLOB = (
+    b"\x02\x3a\x30\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00\x10\x00\x00\x00\x0a\x00\x05\x00"
+)
+
+
+def craft_malformed_payload(payload):
+    """Splice an in-bounds-but-internally-invalid blob into a valid DUMP and re-sign."""
+    pos = payload.find(_ARRAY_SIG)
+    if pos < 0:
+        raise AssertionError(
+            "ARRAY_UINT32 signature for {0,1,2} not found in the DUMP payload; "
+            "the 32-bit serialization format may have changed -- update this test"
+        )
+    prefix_at = pos - 1
+    # RDB stores the 17-byte module string with a single-byte 6-bit length prefix.
+    if payload[prefix_at] != len(_ARRAY_SIG):
+        raise AssertionError(
+            "expected a one-byte RDB length prefix (%d) before the serialized bitmap, "
+            "got 0x%02x -- update this test" % (len(_ARRAY_SIG), payload[prefix_at])
+        )
+    new_string = struct.pack("<B", len(_MALFORMED_UNSORTED_BLOB)) + _MALFORMED_UNSORTED_BLOB
+    tampered = payload[:prefix_at] + new_string + payload[pos + len(_ARRAY_SIG):]
+    return repatch_crc(tampered)
+
+
 def expect(condition, message):
     if condition:
         print("\x1b[32m✓\x1b[0m %s" % message)
@@ -208,6 +242,15 @@ def main():
         reply = client.command("RESTORE", "oob_bad", 0, moderate)
         expect(is_bad_data_error(reply),
                "Crafted moderate-cardinality payload is also rejected")
+
+        # Beyond the size check: a payload that is fully in-bounds (so the safe
+        # deserialize accepts it) but internally inconsistent -- here an unsorted
+        # array container -- must still be rejected by the post-deserialize
+        # validation, as the CRoaring maintainer noted on PR #154.
+        malformed = craft_malformed_payload(payload)
+        reply = client.command("RESTORE", "oob_bad", 0, malformed)
+        expect(is_bad_data_error(reply),
+               "In-bounds but internally-inconsistent payload is rejected by validation")
 
         # The server must have survived the crafted loads.
         expect(client.command("PING") == b"PONG", "Server is still alive after the crafted RESTOREs")

--- a/tests/integration_6.py
+++ b/tests/integration_6.py
@@ -1,19 +1,10 @@
 #!/usr/bin/env python3
-"""Regression test for the unbounded OOB read in BitmapRdbLoad (issue #153).
+"""Regression tests for untrusted bitmap RDB/RESTORE input (issue #153).
 
-src/r_32.c used to deserialize an RDB/RESTORE payload with the unsafe
-roaring_bitmap_deserialize(), which trusts the serialized cardinality header
-and reads that many uint32 elements regardless of the actual buffer length. A
-crafted RESTORE payload (any authenticated client can send one) whose
-ARRAY_UINT32 header declares a huge cardinality therefore drove a large
-out-of-bounds read. The fix switches to roaring_bitmap_deserialize_safe(), which
-bounds every read by the loaded size and returns NULL on a truncated or corrupt
-payload -- Redis then rejects the RESTORE with "Bad data format" and stays up.
-
-This test crafts exactly that payload by taking a valid DUMP of a small bitmap,
-inflating the cardinality field in place, recomputing Redis's CRC64 footer so
-the payload passes RESTORE's checksum check and actually reaches the module
-loader, and asserting the server rejects it cleanly instead of crashing.
+The test mutates valid DUMP payloads, recomputes Redis's CRC64 footer, and sends
+them through RESTORE. It covers truncated CRoaring data, structurally invalid
+32- and 64-bit bitmaps, and malformed Redis module framing. A client must be
+authorized to run RESTORE to reach these loaders.
 
 It talks RESP over a raw socket so it needs no third-party Python packages.
 """
@@ -132,7 +123,6 @@ class RespError(str):
 # and RDB stores the 17-byte buffer verbatim (no compression under 20 bytes), so
 # it appears contiguously inside the DUMP payload.
 _ARRAY_SIG = struct.pack("<BI", 1, 3) + struct.pack("<III", 0, 1, 2)
-_CARD_OFFSET_IN_SIG = 1  # cardinality field starts one byte into the signature
 
 
 def repatch_crc(payload):
@@ -141,17 +131,74 @@ def repatch_crc(payload):
     return body + struct.pack("<Q", crc64(body))
 
 
+def read_rdb_length(payload, pos):
+    """Decode one Redis RDB length and return (value, next position)."""
+    if pos >= len(payload):
+        raise AssertionError("truncated RDB length")
+
+    first = payload[pos]
+    length_type = first >> 6
+    if length_type == 0:
+        return first & 0x3F, pos + 1
+    if length_type == 1:
+        if pos + 2 > len(payload):
+            raise AssertionError("truncated 14-bit RDB length")
+        return ((first & 0x3F) << 8) | payload[pos + 1], pos + 2
+    if first == 0x80:
+        if pos + 5 > len(payload):
+            raise AssertionError("truncated 32-bit RDB length")
+        return struct.unpack(">I", payload[pos + 1:pos + 5])[0], pos + 5
+    if first == 0x81:
+        if pos + 9 > len(payload):
+            raise AssertionError("truncated 64-bit RDB length")
+        return struct.unpack(">Q", payload[pos + 1:pos + 9])[0], pos + 9
+    raise AssertionError("encoded RDB strings are disabled for this test")
+
+
+def encode_rdb_length(length):
+    if length < 64:
+        return bytes([length])
+    if length < 16384:
+        return bytes([0x40 | (length >> 8), length & 0xFF])
+    if length <= 0xFFFFFFFF:
+        return b"\x80" + struct.pack(">I", length)
+    return b"\x81" + struct.pack(">Q", length)
+
+
+def module_string_layout(payload):
+    """Locate the single RedisModule_SaveStringBuffer value in a DUMP."""
+    if len(payload) < 12:
+        raise AssertionError("DUMP payload is too short")
+
+    # Skip the object type and module type id, then require the STRING opcode.
+    _, pos = read_rdb_length(payload, 1)
+    opcode_pos = pos
+    opcode, pos = read_rdb_length(payload, pos)
+    if opcode != 5:
+        raise AssertionError("expected Redis module STRING opcode, got %d" % opcode)
+
+    length_pos = pos
+    string_length, data_pos = read_rdb_length(payload, pos)
+    data_end = data_pos + string_length
+    if data_end >= len(payload) - 10:
+        raise AssertionError("module string extends past the DUMP payload")
+
+    end_opcode, footer_pos = read_rdb_length(payload, data_end)
+    if end_opcode != 0 or footer_pos != len(payload) - 10:
+        raise AssertionError("unexpected data after the module string")
+    return opcode_pos, length_pos, data_pos, data_end
+
+
 def craft_oob_payload(payload, fake_cardinality):
     """Inflate the ARRAY_UINT32 cardinality in a valid DUMP and re-sign it."""
-    pos = payload.find(_ARRAY_SIG)
-    if pos < 0:
+    _, _, data_pos, data_end = module_string_layout(payload)
+    if payload[data_pos:data_end] != _ARRAY_SIG:
         raise AssertionError(
-            "ARRAY_UINT32 signature for {0,1,2} not found in the DUMP payload; "
+            "expected the ARRAY_UINT32 serialization of {0,1,2}; "
             "the 32-bit serialization format may have changed -- update this test"
         )
-    card_at = pos + _CARD_OFFSET_IN_SIG
     tampered = bytearray(payload)
-    tampered[card_at:card_at + 4] = struct.pack("<I", fake_cardinality)
+    tampered[data_pos + 1:data_pos + 5] = struct.pack("<I", fake_cardinality)
     return repatch_crc(bytes(tampered))
 
 
@@ -164,29 +211,35 @@ def craft_oob_payload(payload, fake_cardinality):
 # pinned CRoaring, where deserialize_safe returns non-NULL and internal_validate
 # reports "array elements not strictly increasing". If the vendored CRoaring's
 # portable format ever changes, regenerate this blob.
-_MALFORMED_UNSORTED_BLOB = (
-    b"\x02\x3a\x30\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00\x10\x00\x00\x00\x0a\x00\x05\x00"
+_MALFORMED_PORTABLE_BLOB = (
+    b"\x3a\x30\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00\x10\x00\x00\x00\x0a\x00\x05\x00"
+)
+_MALFORMED_R32_BLOB = b"\x02" + _MALFORMED_PORTABLE_BLOB
+
+# One 64-bit map entry (high bits zero) containing the same malformed portable
+# 32-bit bitmap. The safe 64-bit deserializer accepts the byte lengths, while
+# roaring64_bitmap_internal_validate must reject the unsorted inner container.
+_MALFORMED_R64_BLOB = (
+    struct.pack("<Q", 1) + struct.pack("<I", 0) + _MALFORMED_PORTABLE_BLOB
 )
 
 
-def craft_malformed_payload(payload):
-    """Splice an in-bounds-but-internally-invalid blob into a valid DUMP and re-sign."""
-    pos = payload.find(_ARRAY_SIG)
-    if pos < 0:
-        raise AssertionError(
-            "ARRAY_UINT32 signature for {0,1,2} not found in the DUMP payload; "
-            "the 32-bit serialization format may have changed -- update this test"
-        )
-    prefix_at = pos - 1
-    # RDB stores the 17-byte module string with a single-byte 6-bit length prefix.
-    if payload[prefix_at] != len(_ARRAY_SIG):
-        raise AssertionError(
-            "expected a one-byte RDB length prefix (%d) before the serialized bitmap, "
-            "got 0x%02x -- update this test" % (len(_ARRAY_SIG), payload[prefix_at])
-        )
-    new_string = struct.pack("<B", len(_MALFORMED_UNSORTED_BLOB)) + _MALFORMED_UNSORTED_BLOB
-    tampered = payload[:prefix_at] + new_string + payload[pos + len(_ARRAY_SIG):]
+def replace_module_string(payload, new_value):
+    """Replace a module string in a valid DUMP and re-sign it."""
+    _, length_pos, _, data_end = module_string_layout(payload)
+    new_string = encode_rdb_length(len(new_value)) + new_value
+    tampered = payload[:length_pos] + new_string + payload[data_end:]
     return repatch_crc(tampered)
+
+
+def craft_bad_module_opcode(payload):
+    """Make LoadStringBuffer see the wrong module opcode and re-sign the DUMP."""
+    opcode_pos, _, _, _ = module_string_layout(payload)
+    tampered = bytearray(payload)
+    if tampered[opcode_pos] != 5:
+        raise AssertionError("module STRING opcode is not encoded in one byte")
+    tampered[opcode_pos] = 1  # RDB_MODULE_OPCODE_SINT
+    return repatch_crc(bytes(tampered))
 
 
 def expect(condition, message):
@@ -206,40 +259,46 @@ def main():
     client = RespClient(HOST, port)
     try:
         expect(client.command("PING") == b"PONG", "Server responds to PING")
+        expect(client.command("CONFIG", "SET", "rdbcompression", "no") == b"OK",
+               "Disable RDB compression so crafted module strings are explicit")
 
-        client.command("DEL", "oob_src", "oob_good", "oob_bad")
-        expect(client.command("R.SETINTARRAY", "oob_src", 0, 1, 2) == b"OK",
+        client.command(
+            "DEL",
+            "r32_src", "r32_good", "r32_bad", "r32_bad_framing",
+            "r64_src", "r64_good", "r64_bad", "r64_bad_framing",
+        )
+        expect(client.command("R.SETINTARRAY", "r32_src", 0, 1, 2) == b"OK",
                "Seed a small 32-bit bitmap {0, 1, 2}")
 
-        payload = client.command("DUMP", "oob_src")
-        expect(isinstance(payload, bytes) and len(payload) > 10,
-               "DUMP returns a serialized payload")
+        payload32 = client.command("DUMP", "r32_src")
+        expect(isinstance(payload32, bytes) and len(payload32) > 10,
+               "DUMP returns a serialized 32-bit payload")
 
         # Self-check: our CRC64 must reproduce the footer Redis wrote for this
         # exact payload. If it does not, every crafted RESTORE below would be
         # rejected on the checksum instead of by the module loader, and the test
         # would pass vacuously -- so assert the match up front.
-        recomputed = struct.pack("<Q", crc64(payload[:-8]))
-        expect(recomputed == payload[-8:],
+        recomputed = struct.pack("<Q", crc64(payload32[:-8]))
+        expect(recomputed == payload32[-8:],
                "Ported CRC64 matches the DUMP footer Redis computed")
 
         # A faithfully re-signed but unmodified payload must restore cleanly.
-        expect(client.command("RESTORE", "oob_good", 0, repatch_crc(payload)) == b"OK",
-               "Re-signed unmodified payload restores successfully")
-        expect(client.command("R.GETINTARRAY", "oob_good") == [0, 1, 2],
-               "Restored bitmap round-trips to {0, 1, 2}")
+        expect(client.command("RESTORE", "r32_good", 0, repatch_crc(payload32)) == b"OK",
+               "Re-signed unmodified 32-bit payload restores successfully")
+        expect(client.command("R.GETINTARRAY", "r32_good") == [0, 1, 2],
+               "Restored 32-bit bitmap round-trips to {0, 1, 2}")
 
         # The attack: a huge declared cardinality with a short buffer. The old
         # unsafe deserialize would read ~16 GB past the 17-byte buffer; the safe
         # variant returns NULL and Redis reports "Bad data format".
-        huge = craft_oob_payload(payload, 0xFFFFFFFF)
-        reply = client.command("RESTORE", "oob_bad", 0, huge)
+        huge = craft_oob_payload(payload32, 0xFFFFFFFF)
+        reply = client.command("RESTORE", "r32_bad", 0, huge)
         expect(is_bad_data_error(reply),
                "Crafted huge-cardinality payload is rejected with 'Bad data format'")
 
         # A smaller-but-still-out-of-bounds cardinality must be rejected too.
-        moderate = craft_oob_payload(payload, 1000)
-        reply = client.command("RESTORE", "oob_bad", 0, moderate)
+        moderate = craft_oob_payload(payload32, 1000)
+        reply = client.command("RESTORE", "r32_bad", 0, moderate)
         expect(is_bad_data_error(reply),
                "Crafted moderate-cardinality payload is also rejected")
 
@@ -247,16 +306,53 @@ def main():
         # deserialize accepts it) but internally inconsistent -- here an unsorted
         # array container -- must still be rejected by the post-deserialize
         # validation, as the CRoaring maintainer noted on PR #154.
-        malformed = craft_malformed_payload(payload)
-        reply = client.command("RESTORE", "oob_bad", 0, malformed)
+        malformed32 = replace_module_string(payload32, _MALFORMED_R32_BLOB)
+        reply = client.command("RESTORE", "r32_bad", 0, malformed32)
         expect(is_bad_data_error(reply),
-               "In-bounds but internally-inconsistent payload is rejected by validation")
+               "Structurally invalid 32-bit payload is rejected by validation")
+
+        # Redis module framing is outside CRoaring. Without opting in to and
+        # checking recoverable module I/O errors, LoadStringBuffer panics Redis
+        # when it encounters an unexpected opcode.
+        bad_framing32 = craft_bad_module_opcode(payload32)
+        reply = client.command("RESTORE", "r32_bad_framing", 0, bad_framing32)
+        expect(is_bad_data_error(reply),
+               "Malformed 32-bit module framing is rejected without aborting Redis")
+        expect(client.command("PING") == b"PONG",
+               "Server survives malformed 32-bit module framing")
+        expect(client.command("EXISTS", "r32_bad", "r32_bad_framing") == 0,
+               "Rejected 32-bit payloads create no keys")
+
+        # Exercise Lemire's requested structural validation independently on the
+        # 64-bit loader, including a valid round-trip as a non-regression check.
+        expect(client.command("R64.SETINTARRAY", "r64_src", 0, 1, 2) == b"OK",
+               "Seed a small 64-bit bitmap {0, 1, 2}")
+        payload64 = client.command("DUMP", "r64_src")
+        expect(isinstance(payload64, bytes) and len(payload64) > 10,
+               "DUMP returns a serialized 64-bit payload")
+        expect(struct.pack("<Q", crc64(payload64[:-8])) == payload64[-8:],
+               "CRC64 matches the 64-bit DUMP footer")
+        expect(client.command("RESTORE", "r64_good", 0, repatch_crc(payload64)) == b"OK",
+               "Re-signed unmodified 64-bit payload restores successfully")
+        expect(client.command("R64.GETINTARRAY", "r64_good") == [0, 1, 2],
+               "Restored 64-bit bitmap round-trips to {0, 1, 2}")
+
+        malformed64 = replace_module_string(payload64, _MALFORMED_R64_BLOB)
+        reply = client.command("RESTORE", "r64_bad", 0, malformed64)
+        expect(is_bad_data_error(reply),
+               "Structurally invalid 64-bit payload is rejected by validation")
+
+        bad_framing64 = craft_bad_module_opcode(payload64)
+        reply = client.command("RESTORE", "r64_bad_framing", 0, bad_framing64)
+        expect(is_bad_data_error(reply),
+               "Malformed 64-bit module framing is rejected without aborting Redis")
 
         # The server must have survived the crafted loads.
         expect(client.command("PING") == b"PONG", "Server is still alive after the crafted RESTOREs")
-        expect(client.command("EXISTS", "oob_bad") == 0, "No key was created from the rejected payloads")
+        expect(client.command("EXISTS", "r64_bad", "r64_bad_framing") == 0,
+               "Rejected 64-bit payloads create no keys")
 
-        print("\nAll integration (6) OOB deserialization tests passed")
+        print("\nAll integration (6) untrusted deserialization tests passed")
     finally:
         client.close()
 

--- a/tests/integration_6.py
+++ b/tests/integration_6.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Regression test for the unbounded OOB read in BitmapRdbLoad (issue #153).
+
+src/r_32.c used to deserialize an RDB/RESTORE payload with the unsafe
+roaring_bitmap_deserialize(), which trusts the serialized cardinality header
+and reads that many uint32 elements regardless of the actual buffer length. A
+crafted RESTORE payload (any authenticated client can send one) whose
+ARRAY_UINT32 header declares a huge cardinality therefore drove a large
+out-of-bounds read. The fix switches to roaring_bitmap_deserialize_safe(), which
+bounds every read by the loaded size and returns NULL on a truncated or corrupt
+payload -- Redis then rejects the RESTORE with "Bad data format" and stays up.
+
+This test crafts exactly that payload by taking a valid DUMP of a small bitmap,
+inflating the cardinality field in place, recomputing Redis's CRC64 footer so
+the payload passes RESTORE's checksum check and actually reaches the module
+loader, and asserting the server rejects it cleanly instead of crashing.
+
+It talks RESP over a raw socket so it needs no third-party Python packages.
+"""
+
+import os
+import socket
+import struct
+import sys
+
+HOST = "127.0.0.1"
+
+
+# --- Redis CRC64 (jones poly, reflected in/out), ported from deps/redis/src/crc64.c.
+# Verified against Redis's own test vectors: crc64("123456789") == 0xe9c6d914c4b8d9ca.
+_POLY = 0xAD93D23594C935A9
+_MASK = 0xFFFFFFFFFFFFFFFF
+
+
+def _reflect64(data):
+    result = 0
+    for i in range(64):
+        result = (result << 1) | ((data >> i) & 1)
+    return result
+
+
+def crc64(data):
+    crc = 0
+    for byte in data:
+        i = 1
+        while i & 0xFF:
+            bit = crc & 0x8000000000000000
+            if byte & i:
+                bit = 0 if bit else 1
+            crc = (crc << 1) & _MASK
+            if bit:
+                crc ^= _POLY
+            i <<= 1
+    return _reflect64(crc & _MASK)
+
+
+class RespClient:
+    def __init__(self, host, port):
+        self._sock = socket.create_connection((host, port), timeout=30)
+        self._buf = b""
+
+    def close(self):
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+    def command(self, *args):
+        parts = [b"*%d\r\n" % len(args)]
+        for arg in args:
+            if isinstance(arg, str):
+                arg = arg.encode()
+            elif isinstance(arg, int):
+                arg = str(arg).encode()
+            parts.append(b"$%d\r\n" % len(arg))
+            parts.append(arg)
+            parts.append(b"\r\n")
+        self._sock.sendall(b"".join(parts))
+        return self._read_reply()
+
+    def _read_line(self):
+        while b"\r\n" not in self._buf:
+            self._fill()
+        line, self._buf = self._buf.split(b"\r\n", 1)
+        return line
+
+    def _read_n(self, n):
+        # n bytes plus the trailing CRLF.
+        while len(self._buf) < n + 2:
+            self._fill()
+        data = self._buf[:n]
+        self._buf = self._buf[n + 2:]
+        return data
+
+    def _fill(self):
+        chunk = self._sock.recv(65536)
+        if not chunk:
+            raise ConnectionError("server closed the connection")
+        self._buf += chunk
+
+    def _read_reply(self):
+        line = self._read_line()
+        prefix, rest = line[:1], line[1:]
+        if prefix == b"+":
+            return rest
+        if prefix == b"-":
+            return RespError(rest.decode(errors="replace"))
+        if prefix == b":":
+            return int(rest)
+        if prefix == b"$":
+            length = int(rest)
+            if length == -1:
+                return None
+            return self._read_n(length)
+        if prefix == b"*":
+            count = int(rest)
+            if count == -1:
+                return None
+            return [self._read_reply() for _ in range(count)]
+        raise ValueError("unexpected reply: %r" % line)
+
+
+class RespError(str):
+    """A RESP error reply, kept distinct from a normal string reply."""
+
+
+# The 32-bit CRoaring ARRAY_UINT32 serialization of the set {0, 1, 2}:
+#   byte 0     : format tag CROARING_SERIALIZATION_ARRAY_UINT32 (0x01)
+#   bytes 1..4 : cardinality = 3 (little-endian uint32)
+#   bytes 5..16: elements 0, 1, 2 (little-endian uint32 each)
+# roaring_bitmap_serialize() picks this array form for such a small sparse set,
+# and RDB stores the 17-byte buffer verbatim (no compression under 20 bytes), so
+# it appears contiguously inside the DUMP payload.
+_ARRAY_SIG = struct.pack("<BI", 1, 3) + struct.pack("<III", 0, 1, 2)
+_CARD_OFFSET_IN_SIG = 1  # cardinality field starts one byte into the signature
+
+
+def repatch_crc(payload):
+    """Return payload with its trailing 8-byte CRC64 footer recomputed."""
+    body = payload[:-8]
+    return body + struct.pack("<Q", crc64(body))
+
+
+def craft_oob_payload(payload, fake_cardinality):
+    """Inflate the ARRAY_UINT32 cardinality in a valid DUMP and re-sign it."""
+    pos = payload.find(_ARRAY_SIG)
+    if pos < 0:
+        raise AssertionError(
+            "ARRAY_UINT32 signature for {0,1,2} not found in the DUMP payload; "
+            "the 32-bit serialization format may have changed -- update this test"
+        )
+    card_at = pos + _CARD_OFFSET_IN_SIG
+    tampered = bytearray(payload)
+    tampered[card_at:card_at + 4] = struct.pack("<I", fake_cardinality)
+    return repatch_crc(bytes(tampered))
+
+
+def expect(condition, message):
+    if condition:
+        print("\x1b[32m✓\x1b[0m %s" % message)
+    else:
+        print("\x1b[31m✗\x1b[0m %s" % message)
+        raise SystemExit(1)
+
+
+def is_bad_data_error(reply):
+    return isinstance(reply, RespError) and "Bad data format" in reply
+
+
+def main():
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+    client = RespClient(HOST, port)
+    try:
+        expect(client.command("PING") == b"PONG", "Server responds to PING")
+
+        client.command("DEL", "oob_src", "oob_good", "oob_bad")
+        expect(client.command("R.SETINTARRAY", "oob_src", 0, 1, 2) == b"OK",
+               "Seed a small 32-bit bitmap {0, 1, 2}")
+
+        payload = client.command("DUMP", "oob_src")
+        expect(isinstance(payload, bytes) and len(payload) > 10,
+               "DUMP returns a serialized payload")
+
+        # Self-check: our CRC64 must reproduce the footer Redis wrote for this
+        # exact payload. If it does not, every crafted RESTORE below would be
+        # rejected on the checksum instead of by the module loader, and the test
+        # would pass vacuously -- so assert the match up front.
+        recomputed = struct.pack("<Q", crc64(payload[:-8]))
+        expect(recomputed == payload[-8:],
+               "Ported CRC64 matches the DUMP footer Redis computed")
+
+        # A faithfully re-signed but unmodified payload must restore cleanly.
+        expect(client.command("RESTORE", "oob_good", 0, repatch_crc(payload)) == b"OK",
+               "Re-signed unmodified payload restores successfully")
+        expect(client.command("R.GETINTARRAY", "oob_good") == [0, 1, 2],
+               "Restored bitmap round-trips to {0, 1, 2}")
+
+        # The attack: a huge declared cardinality with a short buffer. The old
+        # unsafe deserialize would read ~16 GB past the 17-byte buffer; the safe
+        # variant returns NULL and Redis reports "Bad data format".
+        huge = craft_oob_payload(payload, 0xFFFFFFFF)
+        reply = client.command("RESTORE", "oob_bad", 0, huge)
+        expect(is_bad_data_error(reply),
+               "Crafted huge-cardinality payload is rejected with 'Bad data format'")
+
+        # A smaller-but-still-out-of-bounds cardinality must be rejected too.
+        moderate = craft_oob_payload(payload, 1000)
+        reply = client.command("RESTORE", "oob_bad", 0, moderate)
+        expect(is_bad_data_error(reply),
+               "Crafted moderate-cardinality payload is also rejected")
+
+        # The server must have survived the crafted loads.
+        expect(client.command("PING") == b"PONG", "Server is still alive after the crafted RESTOREs")
+        expect(client.command("EXISTS", "oob_bad") == 0, "No key was created from the rejected payloads")
+
+        print("\nAll integration (6) OOB deserialization tests passed")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except OSError as exc:
+        print("integration_6 failed: %s" % exc, file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -44,6 +44,7 @@
 #include "unit/test_bitmap64_jaccard.c"
 #include "unit/test_bitmap_jaccard.c"
 #include "unit/test_bitop_keys.c"
+#include "unit/test_bitmap_rdb.c"
 
 int main(int argc, char* argv[]) {
   test_start();
@@ -89,6 +90,7 @@ int main(int argc, char* argv[]) {
   test_bitmap_intersect();
   test_bitmap_jaccard();
   test_bitop_keys();
+  test_bitmap_rdb();
 
   test_end();
 

--- a/tests/unit/test_bitmap_rdb.c
+++ b/tests/unit/test_bitmap_rdb.c
@@ -1,0 +1,49 @@
+#include "bitmap_rdb.h"
+#include "../test-utils.h"
+
+static void SetSerializedCardinality(char* serialized_bitmap, uint32_t cardinality) {
+  memcpy(serialized_bitmap + 1, &cardinality, sizeof(cardinality));
+}
+
+void test_bitmap_rdb() {
+  DESCRIBE("bitmap RDB bounds validation")
+  {
+    IT("Should accept a complete native array serialization")
+    {
+      char serialized_bitmap[17] = {1};
+      SetSerializedCardinality(serialized_bitmap, 3);
+      ASSERT(BitmapSerializedArrayFits(serialized_bitmap, sizeof(serialized_bitmap)),
+             "three uint32_t values should fit in a 17-byte serialization");
+    }
+
+    IT("Should reject truncated cardinalities without overflowing size_t")
+    {
+      char serialized_bitmap[17] = {1};
+
+      SetSerializedCardinality(serialized_bitmap, 4);
+      ASSERT(!BitmapSerializedArrayFits(serialized_bitmap, sizeof(serialized_bitmap)),
+             "four uint32_t values should not fit in a 17-byte serialization");
+
+      SetSerializedCardinality(serialized_bitmap, UINT32_C(0x40000000));
+      ASSERT(!BitmapSerializedArrayFits(serialized_bitmap, sizeof(serialized_bitmap)),
+             "a cardinality whose byte size wraps 32-bit size_t must be rejected");
+
+      SetSerializedCardinality(serialized_bitmap, UINT32_MAX);
+      ASSERT(!BitmapSerializedArrayFits(serialized_bitmap, sizeof(serialized_bitmap)),
+             "UINT32_MAX cardinality must be rejected");
+    }
+
+    IT("Should reject missing array headers and delegate other formats")
+    {
+      char short_array[] = {1};
+      char container_format[] = {2};
+
+      ASSERT(!BitmapSerializedArrayFits(NULL, 1), "NULL input must be rejected");
+      ASSERT(!BitmapSerializedArrayFits(short_array, 0), "empty input must be rejected");
+      ASSERT(!BitmapSerializedArrayFits(short_array, sizeof(short_array)),
+             "a truncated array header must be rejected");
+      ASSERT(BitmapSerializedArrayFits(container_format, sizeof(container_format)),
+             "other formats should be delegated to CRoaring");
+    }
+  }
+}


### PR DESCRIPTION
Fixes #153.

## Security impact

The 32-bit RDB loader passed an untrusted module string to
`roaring_bitmap_deserialize()`. The native array encoding trusts its serialized
cardinality, so a checksum-valid `RESTORE` payload could make CRoaring read well
past the end of the Redis-owned buffer. In testing, this both disclosed adjacent
heap data for small overreads and crashed Redis for large cardinalities.

The loader is reachable by clients authorized to run `RESTORE`; a corrupt or
malicious RDB file can reach the same path while loading data.

The initial switch to `roaring_bitmap_deserialize_safe()` was necessary but not
sufficient:

- As Daniel Lemire noted in review, the safe APIs bound reads but do not fully
  validate the deserialized data structure. Both the 32- and 64-bit results must
  be checked with their `internal_validate` functions before use.
- In the pinned CRoaring version, the native-array size expression can wrap
  `size_t` on a 32-bit build. A tiny buffer with a forged cardinality can
  therefore pass the library's size check.
- Redis module framing is parsed before CRoaring sees the bytes. An unexpected
  module opcode makes `RedisModule_LoadStringBuffer()` report an I/O error and,
  unless the module opts into recoverable I/O errors, Redis aborts.

## Fix

- Use the size-bounded deserializers for both bitmap widths.
- Run `roaring_bitmap_internal_validate()` and
  `roaring64_bitmap_internal_validate()` before exposing either loaded object.
- Preflight the 32-bit native-array cardinality with subtraction/division-based
  bounds arithmetic, which cannot wrap on 32-bit platforms.
- Enable `REDISMODULE_OPTIONS_HANDLE_IO_ERRORS` and check the module I/O state
  after every RDB string load, so malformed framing is rejected rather than
  panicking the server.
- Free every partially loaded bitmap/buffer on rejection and leave no key
  behind.

Valid existing RDB/DUMP payloads and the on-disk serialization format are
unchanged.

## Regression coverage

`tests/integration_6.py` mutates real 32- and 64-bit `DUMP` payloads and
recomputes Redis's CRC64 footer, ensuring each case reaches the module loader.
It covers:

- huge and moderate forged 32-bit cardinalities;
- in-bounds but structurally invalid 32-bit and 64-bit bitmaps (the review case
  that requires `internal_validate`);
- invalid Redis module string opcodes for both bitmap types;
- valid round trips, server survival, and absence of keys after every rejected
  load.

A dedicated CI job builds both the unit binary and module as actual 32-bit ELF
files and runs the overflow regression there.

## Verification

- Full unit and integration suite: passed.
- 32-bit GCC build and all 264 unit tests: passed.
- Clang/UBSan build, all 264 unit tests, and live Redis integration test: passed
  with no sanitizer findings.
- Focused Valgrind run of the crafted RDB/RESTORE cases: passed with no invalid
  reads, invalid writes, or leaks.
